### PR TITLE
Image Downloader changed to handle edge cases for Basic and Carousel Template 

### DIFF
--- a/AEPNotificationContent/Sources/Controllers/BasicTemplateController.swift
+++ b/AEPNotificationContent/Sources/Controllers/BasicTemplateController.swift
@@ -92,7 +92,6 @@ class BasicTemplateController: TemplateController {
     /// Configure and setup the view with the downloaded image
     /// - Parameter downloadedImage: UIImage object
     private func setupView(withImage downloadedImage: UIImage?) {
-
         // Add imageView to template UI only if image is downloaded
         if let image = downloadedImage {
             imageView.image = image
@@ -114,7 +113,7 @@ class BasicTemplateController: TemplateController {
         titleBodyView.translatesAutoresizingMaskIntoConstraints = false
         titleBodyHeight = titleBodyView.viewHeight
         view.addSubview(titleBodyView)
-        
+
         // Update constraints for titleBodyView based on whether or not the imageView exists
         let titleBodyViewTopAnchor = downloadedImage != nil ? imageView.bottomAnchor : view.safeAreaLayoutGuide.topAnchor
         NSLayoutConstraint.activate([

--- a/AEPNotificationContent/Sources/Controllers/BasicTemplateController.swift
+++ b/AEPNotificationContent/Sources/Controllers/BasicTemplateController.swift
@@ -69,17 +69,19 @@ class BasicTemplateController: TemplateController {
         // Show loading indicator until the image is downloaded
         showLoadingIndicator()
         let imageURLString = payload.basicImageURL.absoluteString
-        ImageDownloader().downloadImages(urls: [imageURLString], completion: { result in
-            self.removeLoadingIndicator()
+        ImageDownloader().downloadImages(urls: [imageURLString], completion: { [weak self] downloadedImages in
+            guard let self = self else { return }
+            removeLoadingIndicator()
+            let result = downloadedImages[imageURLString]
             switch result {
-            case let .success(images):
-                if let image = images[imageURLString] {
-                    self.setupView(withImage: image)
-                }
+            case let .success(image):
+                setupView(withImage: image)
             case let .failure(error):
-                print(error)
-                self.removeFromParent()
-                self.delegate.templateFailedToLoad()
+                print("BasicTemplateController : Image failed to download. Reason: \(error.description)")
+                setupView(withImage: nil)
+            case .none:
+                print("BasicTemplateController : Image not found in downloaded results. Unexpected error.")
+                setupView(withImage: nil)
             }
         })
     }
@@ -88,27 +90,31 @@ class BasicTemplateController: TemplateController {
 
     /// Configure and setup the view with the downloaded image
     /// - Parameter downloadedImage: UIImage object
-    private func setupView(withImage downloadedImage: UIImage) {
-        imageView.image = downloadedImage
-        view.addSubview(imageView)
+    private func setupView(withImage downloadedImage: UIImage?) {
+        if let image = downloadedImage {
+            imageView.image = image
+            view.addSubview(imageView)
 
-        /// keeping height of the image view as half of the notification width.
-        /// This is to maintain the recommended aspect ratio of 2:1
-        imageViewHeight = (view.frame.width / 2)
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            imageView.heightAnchor.constraint(equalToConstant: view.frame.width / 2),
-        ])
+            /// keeping height of the image view as half of the notification width.
+            /// This is to maintain the recommended aspect ratio of 2:1
+            imageViewHeight = (view.frame.width / 2)
+            NSLayoutConstraint.activate([
+                imageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+                imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                imageView.heightAnchor.constraint(equalToConstant: view.frame.width / 2),
+            ])
+        }
 
         titleBodyView.setupWith(payload: payload.titleBodyPayload, viewWidth: view.frame.width - (2 * SIDE_MARGIN))
         titleBodyView.changeColor(from: payload)
         titleBodyView.translatesAutoresizingMaskIntoConstraints = false
         titleBodyHeight = titleBodyView.viewHeight
         view.addSubview(titleBodyView)
+        // Update constraints for titleBodyView based on whether or not the imageView exists
+        let titleBodyViewTopAnchor = downloadedImage != nil ? imageView.bottomAnchor : view.safeAreaLayoutGuide.topAnchor
         NSLayoutConstraint.activate([
-            titleBodyView.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: TOP_MARGIN),
+            titleBodyView.topAnchor.constraint(equalTo: titleBodyViewTopAnchor, constant: TOP_MARGIN),
             titleBodyView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: SIDE_MARGIN),
             titleBodyView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -SIDE_MARGIN),
             titleBodyView.heightAnchor.constraint(equalToConstant: titleBodyHeight),

--- a/AEPNotificationContent/Sources/Controllers/BasicTemplateController.swift
+++ b/AEPNotificationContent/Sources/Controllers/BasicTemplateController.swift
@@ -66,11 +66,12 @@ class BasicTemplateController: TemplateController {
     // MARK: - ViewController lifecycle method
 
     override func viewDidLoad() {
-        // Show loading indicator until the image is downloaded
+        // show loading indicator until the image is downloaded
         showLoadingIndicator()
         let imageURLString = payload.basicImageURL.absoluteString
         ImageDownloader().downloadImages(urls: [imageURLString], completion: { [weak self] downloadedImages in
             guard let self = self else { return }
+            // remove loading indicator
             removeLoadingIndicator()
             let result = downloadedImages[imageURLString]
             switch result {
@@ -91,6 +92,8 @@ class BasicTemplateController: TemplateController {
     /// Configure and setup the view with the downloaded image
     /// - Parameter downloadedImage: UIImage object
     private func setupView(withImage downloadedImage: UIImage?) {
+
+        // Add imageView to template UI only if image is downloaded
         if let image = downloadedImage {
             imageView.image = image
             view.addSubview(imageView)
@@ -111,6 +114,7 @@ class BasicTemplateController: TemplateController {
         titleBodyView.translatesAutoresizingMaskIntoConstraints = false
         titleBodyHeight = titleBodyView.viewHeight
         view.addSubview(titleBodyView)
+        
         // Update constraints for titleBodyView based on whether or not the imageView exists
         let titleBodyViewTopAnchor = downloadedImage != nil ? imageView.bottomAnchor : view.safeAreaLayoutGuide.topAnchor
         NSLayoutConstraint.activate([

--- a/AEPNotificationContent/Sources/Controllers/CarouselTemplateController.swift
+++ b/AEPNotificationContent/Sources/Controllers/CarouselTemplateController.swift
@@ -115,7 +115,7 @@ class CarouselTemplateController: TemplateController, UIScrollViewDelegate {
             // Keep only the carouselItems that has the image downloaded successfully
             self.payload.carouselItems = self.payload.carouselItems.compactMap { carouselItem in
                 // If no result is found for the imageURL, do not include this carousel item.
-                guard let result = downloadedImages[carouselItem.imageURL] else {                    
+                guard let result = downloadedImages[carouselItem.imageURL] else {
                     return nil
                 }
                 switch result {
@@ -128,13 +128,13 @@ class CarouselTemplateController: TemplateController, UIScrollViewDelegate {
                     return nil
                 }
             }
-            
+
             // If no carousel items are left after filtering, show fallback template
-            if (self.payload.carouselItems.count == 0) {
+            if self.payload.carouselItems.count == 0 {
                 delegate.templateFailedToLoad()
                 return
             }
-            
+
             setupView()
         })
     }
@@ -144,7 +144,7 @@ class CarouselTemplateController: TemplateController, UIScrollViewDelegate {
     func setupView() {
         setupScrollView()
         // setup page control and arrow buttons only if there are more than one carousel items
-        if (payload.carouselItems.count > 1) {
+        if payload.carouselItems.count > 1 {
             setupPageControl()
             setupArrowButtons()
         }

--- a/AEPNotificationContent/Sources/Model/CarouselItem.swift
+++ b/AEPNotificationContent/Sources/Model/CarouselItem.swift
@@ -18,9 +18,9 @@ class CarouselItem {
     // MARK: - Properties
 
     /// The URL to the item's image.
-    let imageURL: URL
+    let imageURL: String
     /// The URL to open when the item is clicked (optional).
-    var clickURL: URL?
+    var clickURL: String?
     /// The image data (will be attached after download).
     var image: UIImage?
     /// The title and body text associated with the item.
@@ -34,12 +34,12 @@ class CarouselItem {
     ///   - notificationContent: The UNNotificationContent object.
     /// - Returns: A `CarouselItem` instance if the dictionary contains valid data, `nil` otherwise.
     init?(dictionary: [String: Any], notificationContent: UNNotificationContent) {
-        /// Fail initialization if we are unable to obtain a valid imageURL from the given dictionary
-        guard let imageString = dictionary[AEPNotificationContentConstants.PayloadKey.Carousel.IMAGE] as? String,
-              let imageURL = URL(string: imageString) else {
+        // If not imageURL is provided, do not create the carousel Item object
+        guard let imageURL = dictionary[AEPNotificationContentConstants.PayloadKey.Carousel.IMAGE] as? String, !imageURL.isEmpty else {
             return nil
         }
         self.imageURL = imageURL
+        self.clickURL = dictionary[AEPNotificationContentConstants.PayloadKey.Carousel.URI] as? String
 
         /// Set carousel items title and body text
         /// Carousel Item title is same as the notification title
@@ -47,10 +47,5 @@ class CarouselItem {
         let titleTxt = notificationContent.expandedTitle ?? notificationContent.title
         let bodyTxt = dictionary[AEPNotificationContentConstants.PayloadKey.Carousel.TEXT] as? String ?? notificationContent.body
         self.titleBodyPayload = TitleBodyPayload(title: titleTxt, body: bodyTxt)
-
-        /// Set the click URL if available and valid, nil otherwise
-        if let clickURLString = dictionary[AEPNotificationContentConstants.PayloadKey.Carousel.URI] as? String {
-            self.clickURL = URL(string: clickURLString)
-        }
     }
 }

--- a/AEPNotificationContent/Sources/Model/CarouselItem.swift
+++ b/AEPNotificationContent/Sources/Model/CarouselItem.swift
@@ -17,9 +17,9 @@ import UIKit
 class CarouselItem {
     // MARK: - Properties
 
-    /// The URL to the item's image.
+    /// The URL string for the carousel item image.
     let imageURL: String
-    /// The URL to open when the item is clicked (optional).
+    /// The URL string for the carousel item click action.
     var clickURL: String?
     /// The image data (will be attached after download).
     var image: UIImage?
@@ -34,7 +34,7 @@ class CarouselItem {
     ///   - notificationContent: The UNNotificationContent object.
     /// - Returns: A `CarouselItem` instance if the dictionary contains valid data, `nil` otherwise.
     init?(dictionary: [String: Any], notificationContent: UNNotificationContent) {
-        // If not imageURL is provided, do not create the carousel Item object
+        // If no imageURL is provided, do not create the carousel Item object
         guard let imageURL = dictionary[AEPNotificationContentConstants.PayloadKey.Carousel.IMAGE] as? String, !imageURL.isEmpty else {
             return nil
         }

--- a/AEPNotificationContent/Sources/Utility/ImageDownloadError.swift
+++ b/AEPNotificationContent/Sources/Utility/ImageDownloadError.swift
@@ -26,10 +26,6 @@ enum ImageDownloadError: Error {
     /// Error indicating that the downloaded data could not be converted into an image.
     case invalidImageData(url: String)
 
-    /// Error representing multiple image downloading errors.
-    /// In batch download scenarios this error aggregates all individual errors into a single error case.
-    case multipleErrors(errors: [ImageDownloadError])
-
     var description: String {
         switch self {
         case .noURL:
@@ -40,9 +36,6 @@ enum ImageDownloadError: Error {
             return "Network error at \(url): \(error.localizedDescription)"
         case let .invalidImageData(url):
             return "Failed to convert downloaded data to image at \(url)"
-        case let .multipleErrors(errors):
-            let errorDescriptions = errors.map { $0.description }
-            return "Image Downloader error: \n" + errorDescriptions.joined(separator: " \n")
         }
     }
 }

--- a/AEPNotificationContent/Sources/Utility/ImageDownloader.swift
+++ b/AEPNotificationContent/Sources/Utility/ImageDownloader.swift
@@ -47,7 +47,7 @@ class ImageDownloader {
     /// Downloads a single image from the given URL.
     ///
     /// - Parameters:
-    ///   - urlString: `URL` of the image to download.
+    ///   - urlString: The URL string for the image to be downloaded.
     ///   - completion: A `Result` value called with the downloaded image or an ImageDownloadError.
     private func downloadImage(_ urlString: String, completion: @escaping (Result<UIImage, ImageDownloadError>) -> Void) {
         // validate the url before downloading

--- a/AEPNotificationContent/Sources/Utility/ImageDownloader.swift
+++ b/AEPNotificationContent/Sources/Utility/ImageDownloader.swift
@@ -17,58 +17,45 @@ class ImageDownloader {
     /// Downloads images from the provided URLs.
     /// - Parameters:
     ///   - urls: Array of string URLs for the images to be downloaded.
-    ///   - completion: A  completion block with `Result` value called with a dictionary of downloaded images or an ImageDownloadError.
-    func downloadImages(urls: [String], completion: @escaping (Result<[String: UIImage], ImageDownloadError>) -> Void) {
+    ///   - completion: A  completion block with dictionary containing the result of each downloaded image
+    func downloadImages(urls: [String], completion: @escaping ([String: Result<UIImage, ImageDownloadError>]) -> Void) {
         // Quick bail out if no URLs are provided
         if urls.isEmpty {
-            completion(.failure(.noURL))
-        }
-
-        // Validate URLs before downloading
-        var cleanURLs: [URL] = []
-        let result = validateURLs(urls: urls)
-        switch result {
-        case let .success(urls):
-            cleanURLs = urls
-        case let .failure(error):
-            completion(.failure(error))
+            completion([:])
         }
 
         // Create a dispatch group to track the download progress
         let downloadGroup = DispatchGroup()
-        var downloadedImages: [String: UIImage] = [:]
+        var downloadedImages: [String: Result<UIImage, ImageDownloadError>] = [:]
         var errors = [ImageDownloadError]()
 
         // Download images concurrently
-        for url in cleanURLs {
+        for urlString in urls {
             downloadGroup.enter()
-            downloadImage(url: url) { result in
-                switch result {
-                case let .success(image):
-                    downloadedImages[url.absoluteString] = image
-                case let .failure(error):
-                    errors.append(error)
-                }
+            downloadImage(urlString) { result in
+                downloadedImages[urlString] = result
                 downloadGroup.leave()
             }
         }
 
         // Notify the main queue when all downloads are complete
         downloadGroup.notify(queue: .main) {
-            if errors.isEmpty {
-                completion(.success(downloadedImages))
-            } else {
-                completion(.failure(.multipleErrors(errors: errors)))
-            }
+            completion(downloadedImages)
         }
     }
 
     /// Downloads a single image from the given URL.
     ///
     /// - Parameters:
-    ///   - url: `URL` of the image to download.
+    ///   - urlString: `URL` of the image to download.
     ///   - completion: A `Result` value called with the downloaded image or an ImageDownloadError.
-    private func downloadImage(url: URL, completion: @escaping (Result<UIImage, ImageDownloadError>) -> Void) {
+    private func downloadImage(_ urlString: String, completion: @escaping (Result<UIImage, ImageDownloadError>) -> Void) {
+        // validate the url before downloading
+        guard let url = URL(string: urlString) else {
+            completion(.failure(.invalidURL(url: urlString)))
+            return
+        }
+
         URLSession.shared.dataTask(with: url) { data, _, error in
             // check for network error
             if let error = error {
@@ -85,32 +72,5 @@ class ImageDownloader {
             // on successful download call the completion with success
             completion(.success(image))
         }.resume()
-    }
-
-    /// Validates a list of URL strings.
-    ///
-    /// This method takes an array of strings, each expected to represent a URL, and attempts to convert them into `URL` objects.
-    /// It checks each string and validates whether it can be transformed into a valid URL
-    ///
-    /// - Parameter urls: An array of strings, where each string is intended to be a URL.
-    /// - Returns: A `Result` type. On success, it contains an array of `URL` objects corresponding to the valid URL strings. On failure, it contains an `ImageDownloaderError`.
-    private func validateURLs(urls: [String]) -> Result<[URL], ImageDownloadError> {
-        var validatedUrls: [URL] = []
-        var errors: [ImageDownloadError] = []
-
-        // Validate URLs
-        for urlString in urls {
-            guard let url = URL(string: urlString) else {
-                errors.append(.invalidURL(url: urlString))
-                continue
-            }
-            validatedUrls.append(url)
-        }
-
-        if !errors.isEmpty {
-            return .failure(.multipleErrors(errors: errors))
-        }
-
-        return .success(validatedUrls)
     }
 }

--- a/AEPNotificationContent/Tests/CarouselItemTests.swift
+++ b/AEPNotificationContent/Tests/CarouselItemTests.swift
@@ -32,8 +32,8 @@ final class CarouselItemTests: XCTestCase {
         
         // verify
         XCTAssertNotNil(carouselItem)
-        XCTAssertEqual(carouselItem?.imageURL, URL(string: "https://www.adobe.com/image.png"))
-        XCTAssertEqual(carouselItem?.clickURL, URL(string: "https://www.adobe.com"))
+        XCTAssertEqual(carouselItem?.imageURL, "https://www.adobe.com/image.png")
+        XCTAssertEqual(carouselItem?.clickURL, "https://www.adobe.com")
         XCTAssertEqual(carouselItem?.titleBodyPayload.title, "Expanded Title")
         XCTAssertEqual(carouselItem?.titleBodyPayload.body, "This is a carousel item")
     }
@@ -90,7 +90,7 @@ final class CarouselItemTests: XCTestCase {
         XCTAssertEqual(carouselItem?.titleBodyPayload.body, "")
     }
 
-    func testInit_with_invalidClickURL() {
+    func testInit_with_noClickURL() {
         // setup
         let dictionary: [String: Any] = [
             "img": "https://www.adobe.com/image.png",
@@ -105,7 +105,6 @@ final class CarouselItemTests: XCTestCase {
         
         // verify the carousel item is created
         XCTAssertNotNil(carouselItem)
-        XCTAssertEqual(carouselItem?.clickURL, nil)
     }
 
     func testInit_with_noExpandedTitle() {

--- a/AEPNotificationContent/Tests/CarouselPayloadTest.swift
+++ b/AEPNotificationContent/Tests/CarouselPayloadTest.swift
@@ -51,12 +51,12 @@ final class CarouselPayloadTest: XCTestCase {
         // Verify
         XCTAssertNotNil(payload)
         XCTAssertEqual(payload?.carouselItems.count, 2)
-        XCTAssertEqual(payload?.carouselItems[0].imageURL, URL(string: "https://example.com/image1.png"))
-        XCTAssertEqual(payload?.carouselItems[0].clickURL, URL(string: "https://example.com/click1"))
+        XCTAssertEqual(payload?.carouselItems[0].imageURL, "https://example.com/image1.png")
+        XCTAssertEqual(payload?.carouselItems[0].clickURL, "https://example.com/click1")
         XCTAssertEqual(payload?.carouselItems[0].titleBodyPayload.title, "Expanded Title")
         XCTAssertEqual(payload?.carouselItems[0].titleBodyPayload.body, "This is a carousel item 1")
-        XCTAssertEqual(payload?.carouselItems[1].imageURL, URL(string: "https://example.com/image2.png"))
-        XCTAssertEqual(payload?.carouselItems[1].clickURL, URL(string: "https://example.com/click2"))
+        XCTAssertEqual(payload?.carouselItems[1].imageURL, "https://example.com/image2.png")
+        XCTAssertEqual(payload?.carouselItems[1].clickURL, "https://example.com/click2")
         XCTAssertEqual(payload?.carouselItems[1].titleBodyPayload.title, "Expanded Title")
         XCTAssertEqual(payload?.carouselItems[1].titleBodyPayload.body, "Notification Body")
         


### PR DESCRIPTION
Following changes were discussed earlier 

Basic Template change:
-  UI to show titleAndBody, if image download fails

Carousel Template change:
- Initially, the carousel template displayed UI elements only when all images were successfully downloaded. The behavior has now been modified to display any CarouselItems for which the images have been successfully downloaded.


Changes to ImageDownloader was necceart to achieve the above

ImageDownloader asyn return changed
from  `Result<[String: UIImage], ImageDownloadError>` 
to  `[String: Result<UIImage, ImageDownloadError>]`

What this means is now ImageDownloader individually gives the result for each downloaded. 


