### PR TITLE
Saving Proposition objects in ContentCardUI to aid tracking

### DIFF
--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		B669ED932C75440000A26954 /* AEPSwiftUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B626E04D2C5EC1F400ED1816 /* AEPSwiftUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B669ED982C75951D00A26954 /* MockTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED972C75951D00A26954 /* MockTemplate.swift */; };
 		B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED992C76655300A26954 /* ContentCardUIError.swift */; };
+		B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -165,6 +166,7 @@
 		B669ED902C75416100A26954 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B669ED972C75951D00A26954 /* MockTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemplate.swift; sourceTree = "<group>"; };
 		B669ED992C76655300A26954 /* ContentCardUIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUIError.swift; sourceTree = "<group>"; };
+		B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateBuilder.swift; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -404,6 +406,7 @@
 				B669ED7A2C75087B00A26954 /* TemplateEventHandler.swift */,
 				B669ED6E2C71DD6B00A26954 /* ContentCardTemplate.swift */,
 				B6F4D1A32C62947F00376045 /* SmallImageTemplate.swift */,
+				B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */,
 			);
 			path = Template;
 			sourceTree = "<group>";
@@ -695,6 +698,7 @@
 				B669ED4D2C6F3BE900A26954 /* AEPStack.swift in Sources */,
 				B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */,
 				B6F4D1A42C62947F00376045 /* SmallImageTemplate.swift in Sources */,
+				B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */,
 				B669ED702C71DE2300A26954 /* ContentCardTemplate.swift in Sources */,
 				B669ED482C6F353E00A26954 /* AEPVStack.swift in Sources */,
 				B669ED4A2C6F355F00A26954 /* AEPVStackView.swift in Sources */,

--- a/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
@@ -45,18 +45,11 @@ public class AEPSwiftUI: NSObject {
                 return
             }
 
-            for eachProposition in propositions {
-                // attempt to retrieve the schema data from the proposition item.
-                guard let schemaData = eachProposition.items.first?.contentCardSchemaData else {
-                    Log.warning(label: Constants.LOG_TAG,
-                                "Failed to retrieve contentCardSchemaData for proposition with ID \(eachProposition.uniqueId). Unable to create ContentCardUI.")
-                    continue
-                }
-
+            for proposition in propositions {
                 // attempt to create a ContentCardUI instance with the schema data.
-                guard let contentCard = ContentCardUI.createInstance(with: schemaData) else {
+                guard let contentCard = ContentCardUI.createInstance(with: proposition) else {
                     Log.warning(label: Constants.LOG_TAG,
-                                "Failed to create ContentCardUI for schemaData : \(schemaData)")
+                                "Failed to create ContentCardUI for proposition with ID: \(proposition.uniqueId)")
                     continue
                 }
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI+EventHandler.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI+EventHandler.swift
@@ -15,16 +15,16 @@ import Foundation
 extension ContentCardUI: TemplateEventHandler {
     /// Called when the templated content card is displayed to the user.
     func onDisplay() {
-        schemaData.track(withEdgeEventType: .display)
+        proposition.items.first?.track(withEdgeEventType: .display)
     }
 
     /// Called when the templated content card is displayed to the user.
     func onDismiss() {
-        schemaData.track(withEdgeEventType: .dismiss)
+        proposition.items.first?.track(withEdgeEventType: .dismiss)
     }
 
     /// Called when the templated content card is interacted by the user
     func onInteract(interactionId: String, actionURL _: URL?) {
-        schemaData.track(interactionId, withEdgeEventType: .interact)
+        proposition.items.first?.track(interactionId, withEdgeEventType: .interact)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// ContentCardUI is a class that holds data for a content card and provides a SwiftUI view representation of that content.
 public class ContentCardUI: Identifiable {
     /// The underlying data model for the content card.
-    let schemaData: ContentCardSchemaData
+    let proposition: Proposition
 
     public let template: any ContentCardTemplate
 
@@ -29,41 +29,33 @@ public class ContentCardUI: Identifiable {
     }()
 
     /// Factory method to create a `ContentCardUI` instance based on the provided schema data.
-    /// - Parameter schemaData: The `ContentCardSchemaData` to be used for the content
-    /// - Returns: An initialized `ContentCardUI` instance, or `nil` if unable to create template from `schemaData`
-    static func createInstance(with schemaData: ContentCardSchemaData) -> ContentCardUI? {
-        // determine the appropriate template based on the template type
-        let template: (any ContentCardTemplate)? = {
-            switch schemaData.templateType {
-            case .smallImage:
-                return SmallImageTemplate(schemaData)
-            case .largeImage, .imageOnly, .unknown:
-                // Currently unsupported template types
-                return nil
-            }
-        }()
-
-        // ensure a valid template is created
-        guard let validTemplate = template else {
+    /// - Parameter proposition: The `Proposition` containing content card template information
+    /// - Returns: An initialized `ContentCardUI` instance, or `nil` if unable to create template from proposition
+    static func createInstance(with proposition: Proposition) -> ContentCardUI? {
+        
+        guard let schemaData = proposition.items.first?.contentCardSchemaData else {
+            return nil
+        }
+                
+        guard let template = TemplateBuilder.buildTemplate(from: schemaData) else {
             return nil
         }
 
-        // Initialize the ContentCardUI with the schema data and template
-        let contentCardUI = ContentCardUI(schemaData, validTemplate)
+        // Initialize the ContentCardUI with the proposition and template
+        let contentCardUI = ContentCardUI(proposition, template)
 
         // set the listener for the template
-        validTemplate.eventHandler = contentCardUI
+        template.eventHandler = contentCardUI
         return contentCardUI
     }
 
     /// Initializes a new `ContentCardUI` instance with the given schema data and template.
     /// - Parameters:
-    ///   - schemaData: The `ContentCardSchemaData` to be used for the content card.
+    ///   - proposition: The `Proposition` containing the content card template's information
     ///   - template: The template that defines the content card's layout and behavior.
-    ///
     /// - Note : This initializer is private to ensure that `ContentCardUI` instances are only created through the `createInstance` factory method.
-    private init(_ schemaData: ContentCardSchemaData, _ template: any ContentCardTemplate) {
-        self.schemaData = schemaData
+    private init(_ proposition: Proposition, _ template: any ContentCardTemplate) {
+        self.proposition = proposition
         self.template = template
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
@@ -1,0 +1,32 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import AEPMessaging
+
+/// Enum responsible for building content card templates based on template types.
+enum TemplateBuilder {
+    
+    /// Builds and returns a content card template based on the provided schema data.
+    ///
+    /// - Parameter schemaData: The content card schema data containing template information
+    /// - Returns: An instance conforming to `ContentCardTemplate` if a supported template type is found, otherwise `nil`.
+    static func buildTemplate(from schemaData: ContentCardSchemaData) -> (any ContentCardTemplate)? {
+        switch schemaData.templateType {
+        case .smallImage:
+            return SmallImageTemplate(schemaData)
+        case .largeImage, .imageOnly, .unknown:
+            // Currently unsupported template types
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
holding on to ContentCardSchemaData class and using them in ContentCardUI was losing the weak reference to proposition instance which is declared as weak variable
https://github.com/adobe/aepsdk-messaging-ios/blob/main/AEPMessaging/Sources/PropositionItem.swift#L40 

Changed the ContentCardUI class to hold on to proposition objects. Tracking is working great!
  