### PR TITLE
Customize Template using ContentCardCustomizer

### DIFF
--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -67,6 +67,9 @@
 		B669ED982C75951D00A26954 /* MockTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED972C75951D00A26954 /* MockTemplate.swift */; };
 		B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED992C76655300A26954 /* ContentCardUIError.swift */; };
 		B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */; };
+		B669EDA02C771E2D00A26954 /* ContentCardCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9F2C771E2D00A26954 /* ContentCardCustomizer.swift */; };
+		B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */; };
+		B669EDA42C779E0600A26954 /* View+CustomModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -167,6 +170,9 @@
 		B669ED972C75951D00A26954 /* MockTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemplate.swift; sourceTree = "<group>"; };
 		B669ED992C76655300A26954 /* ContentCardUIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUIError.swift; sourceTree = "<group>"; };
 		B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateBuilder.swift; sourceTree = "<group>"; };
+		B669ED9F2C771E2D00A26954 /* ContentCardCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCustomizer.swift; sourceTree = "<group>"; };
+		B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPViewModifier.swift; sourceTree = "<group>"; };
+		B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CustomModifiers.swift"; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -395,6 +401,7 @@
 				B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */,
 				B669ED552C6FE92E00A26954 /* ContentCardSchemaData+TemplateContent.swift */,
 				B669ED992C76655300A26954 /* ContentCardUIError.swift */,
+				B669ED9F2C771E2D00A26954 /* ContentCardCustomizer.swift */,
 			);
 			path = ContentCards;
 			sourceTree = "<group>";
@@ -415,6 +422,8 @@
 			isa = PBXGroup;
 			children = (
 				B669ED452C6F2F0E00A26954 /* AEPViewModel.swift */,
+				B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */,
+				B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */,
 				B669ED4B2C6F3BC400A26954 /* AEPStack */,
 				B669ED1D2C6AE0B200A26954 /* AEPImage */,
 				B669ED162C6AC7A500A26954 /* AEPButton */,
@@ -691,15 +700,18 @@
 				B669ED182C6AC82300A26954 /* AEPButtonView.swift in Sources */,
 				B669ED572C70029000A26954 /* ContentCardSchemaData+TemplateContent.swift in Sources */,
 				B669ED1F2C6AE0D500A26954 /* AEPImageView.swift in Sources */,
+				B669EDA42C779E0600A26954 /* View+CustomModifiers.swift in Sources */,
 				B6F4D1A02C62935000376045 /* AEPImage.swift in Sources */,
 				B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */,
 				B669ED212C6AEB7D00A26954 /* ImageSourceType.swift in Sources */,
 				B669ED7B2C75087B00A26954 /* TemplateEventHandler.swift in Sources */,
 				B669ED4D2C6F3BE900A26954 /* AEPStack.swift in Sources */,
+				B669EDA02C771E2D00A26954 /* ContentCardCustomizer.swift in Sources */,
 				B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */,
 				B6F4D1A42C62947F00376045 /* SmallImageTemplate.swift in Sources */,
 				B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */,
 				B669ED702C71DE2300A26954 /* ContentCardTemplate.swift in Sources */,
+				B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */,
 				B669ED482C6F353E00A26954 /* AEPVStack.swift in Sources */,
 				B669ED4A2C6F355F00A26954 /* AEPVStackView.swift in Sources */,
 				B669ED272C6D3B4E00A26954 /* AEPHStack.swift in Sources */,

--- a/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
@@ -22,10 +22,12 @@ public class AEPSwiftUI: NSObject {
     /// Retrieves the content cards UI for a given surface.
     /// - Parameters:
     ///   - surface: The surface for which to retrieve the content cards.
+    ///   - customizer: An optional ContentCardCustomizer object to customize the appearance of the content card template.
     ///   - completion: A completion handler that is called with a `Result` type containing either:
     ///     - success([ContentCardUI]):  An array of `ContentCardUI` objects if the operation is successful.
     ///     - failure(Error) : An error indicating the failure reason
     public static func getContentCardsUI(for surface: Surface,
+                                         customizer: ContentCardCustomizer? = nil,
                                          _ completion: @escaping (Result<[ContentCardUI], Error>) -> Void) {
         // Request propositions for the specified surface from Messaging extension.
         Messaging.getPropositionsForSurfaces([surface]) { propositionDict, error in
@@ -47,7 +49,8 @@ public class AEPSwiftUI: NSObject {
 
             for proposition in propositions {
                 // attempt to create a ContentCardUI instance with the schema data.
-                guard let contentCard = ContentCardUI.createInstance(with: proposition) else {
+                guard let contentCard = ContentCardUI.createInstance(with: proposition,
+                                                                     customizer: customizer) else {
                     Log.warning(label: Constants.LOG_TAG,
                                 "Failed to create ContentCardUI for proposition with ID: \(proposition.uniqueId)")
                     continue

--- a/Frameworks/AEPSwiftUI/Sources/Constants.swift
+++ b/Frameworks/AEPSwiftUI/Sources/Constants.swift
@@ -22,7 +22,7 @@ enum Constants {
         static let ImageOnly = "ImageOnly"
 
         enum InteractionID {
-            // TODO : Verify with PM to see if this Interaction event name makes sense of all platforms 
+            // TODO: Verify with PM to see if this Interaction event name makes sense of all platforms
             static let cardTapped = "Card Clicked"
         }
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizer.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizer.swift
@@ -1,0 +1,19 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+/// Protocol for customizing Content Card templates,
+public protocol ContentCardCustomizer {
+    /// Implement this function to customize content cards with SmallImageTemplate
+    func customize(template: SmallImageTemplate)
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizer.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizer.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-/// Protocol for customizing Content Card templates,
+/// Protocol for customizing Content Card templates
 public protocol ContentCardCustomizer {
     /// Implement this function to customize content cards with SmallImageTemplate
     func customize(template: SmallImageTemplate)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI+EventHandler.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI+EventHandler.swift
@@ -15,16 +15,16 @@ import Foundation
 extension ContentCardUI: TemplateEventHandler {
     /// Called when the templated content card is displayed to the user.
     func onDisplay() {
-        proposition.items.first?.track(withEdgeEventType: .display)
+        proposition.items.first?.contentCardSchemaData?.track(withEdgeEventType: .display)
     }
 
     /// Called when the templated content card is displayed to the user.
     func onDismiss() {
-        proposition.items.first?.track(withEdgeEventType: .dismiss)
+        proposition.items.first?.contentCardSchemaData?.track(withEdgeEventType: .dismiss)
     }
 
     /// Called when the templated content card is interacted by the user
     func onInteract(interactionId: String, actionURL _: URL?) {
-        proposition.items.first?.track(interactionId, withEdgeEventType: .interact)
+        proposition.items.first?.contentCardSchemaData?.track(interactionId, withEdgeEventType: .interact)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
@@ -29,15 +29,18 @@ public class ContentCardUI: Identifiable {
     }()
 
     /// Factory method to create a `ContentCardUI` instance based on the provided schema data.
-    /// - Parameter proposition: The `Proposition` containing content card template information
+    /// - Parameters:
+    ///    - proposition: The `Proposition` containing content card template information
+    ///    - customizer: An object conforming to `ContentCardUICustomizer` protocol that allows for
+    ///                 custom styling of the content card
     /// - Returns: An initialized `ContentCardUI` instance, or `nil` if unable to create template from proposition
-    static func createInstance(with proposition: Proposition) -> ContentCardUI? {
-        
+    static func createInstance(with proposition: Proposition,
+                               customizer: ContentCardCustomizer?) -> ContentCardUI? {
         guard let schemaData = proposition.items.first?.contentCardSchemaData else {
             return nil
         }
-                
-        guard let template = TemplateBuilder.buildTemplate(from: schemaData) else {
+
+        guard let template = TemplateBuilder.buildTemplate(from: schemaData, customizer: customizer) else {
             return nil
         }
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
@@ -44,8 +44,6 @@ public class BaseTemplate: ObservableObject {
     /// - Parameter schemaData: The schema data used for initialization.
     init?(_ schemaData: ContentCardSchemaData) {
         self.actionURL = schemaData.actionUrl
-
-        // TODO: Retrieve other common properties for all templated content cards
     }
 
     /// Constructs a SwiftUI view with common properties and behaviors applied for all templates.

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
@@ -55,9 +55,12 @@ public class SmallImageTemplate: BaseTemplate, ContentCardTemplate {
     /// This initializer extracts the title, body, image, and buttons from the provided `ContentCardSchemaData`.
     /// It organizes these components into the appropriate stacks to form the small Image layout.
     ///
-    /// - Parameter schemaData: The schema data used to populate the template's properties.
+    /// - Parameters:
+    ///    - schemaData: The schema data used to populate the template's properties.
+    ///    - customizer: An object conforming to ContentCardUICustomizer protocol that allows for
+    ///                 custom styling of the content card
     /// - Returns: An initialized `SmallImageTemplate` or `nil` if the required title is missing.
-    override init?(_ schemaData: ContentCardSchemaData) {
+    init?(_ schemaData: ContentCardSchemaData, _ customizer: ContentCardCustomizer?) {
         guard let title = schemaData.title else {
             return nil
         }
@@ -88,5 +91,7 @@ public class SmallImageTemplate: BaseTemplate, ContentCardTemplate {
             rootHStack.addModel(image)
         }
         rootHStack.addModel(textVStack)
+
+        customizer?.customize(template: self)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
@@ -10,20 +10,23 @@
  governing permissions and limitations under the License.
  */
 
-import Foundation
 import AEPMessaging
+import Foundation
 
 /// Enum responsible for building content card templates based on template types.
 enum TemplateBuilder {
-    
     /// Builds and returns a content card template based on the provided schema data.
     ///
-    /// - Parameter schemaData: The content card schema data containing template information
+    /// - Parameters:
+    ///    - schemaData: The content card schema data containing template information.
+    ///    - customizer: An object conforming to `ContentCardUICustomizer` protocol that allows for
+    ///                 custom styling of the content card
     /// - Returns: An instance conforming to `ContentCardTemplate` if a supported template type is found, otherwise `nil`.
-    static func buildTemplate(from schemaData: ContentCardSchemaData) -> (any ContentCardTemplate)? {
+    static func buildTemplate(from schemaData: ContentCardSchemaData,
+                              customizer: ContentCardCustomizer?) -> (any ContentCardTemplate)? {
         switch schemaData.templateType {
         case .smallImage:
-            return SmallImageTemplate(schemaData)
+            return SmallImageTemplate(schemaData, customizer)
         case .largeImage, .imageOnly, .unknown:
             // Currently unsupported template types
             return nil

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateEventHandler.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateEventHandler.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-protocol TemplateEventHandler : AnyObject {
+protocol TemplateEventHandler: AnyObject {
     /// Called when the templated content card appears on the screen
     func onDisplay()
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
@@ -23,7 +23,7 @@ public class AEPButton: ObservableObject, AEPViewModel {
     /// the URL to be opened when the button is tapped.
     @Published public var actionUrl: URL?
 
-    /// custom view modifier that can be applied to the text view.
+    /// custom view modifier that can be applied to the button view.
     @Published public var modifier: AEPViewModifier?
 
     /// The parent template that contains this button.

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
@@ -14,9 +14,19 @@ import SwiftUI
 
 // The model class representing the button UI element of the ContentCard.
 public class AEPButton: ObservableObject, AEPViewModel {
+    /// the text model for the button's label.
     @Published public var text: AEPText
+
+    /// unique identifier for tracking button interactions.
     @Published public var interactId: String
+
+    /// the URL to be opened when the button is tapped.
     @Published public var actionUrl: URL?
+
+    /// custom view modifier that can be applied to the text view.
+    @Published public var modifier: AEPViewModifier?
+
+    /// The parent template that contains this button.
     let parentTemplate: any ContentCardTemplate
 
     public lazy var view: some View = AEPButtonView(model: self)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButtonView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButtonView.swift
@@ -29,5 +29,6 @@ public struct AEPButtonView: View {
         }, label: {
             model.text.view
         })
+        .applyModifier(model.modifier)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
@@ -27,7 +27,7 @@ public class AEPImage: ObservableObject, AEPViewModel {
     /// The name of the dark mode image bundled resource.
     var darkBundle: String?
 
-    /// custom view modifier that can be applied to the text view.
+    /// custom view modifier that can be applied to the image view.
     @Published public var modifier: AEPViewModifier?
 
     /// The content mode of the image.

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
@@ -27,6 +27,9 @@ public class AEPImage: ObservableObject, AEPViewModel {
     /// The name of the dark mode image bundled resource.
     var darkBundle: String?
 
+    /// custom view modifier that can be applied to the text view.
+    @Published public var modifier: AEPViewModifier?
+
     /// The content mode of the image.
     @Published public var contentMode: ContentMode = .fit
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImageView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImageView.swift
@@ -46,7 +46,7 @@ struct AEPImageView: View {
                     .resizable()
                     .aspectRatio(contentMode: model.contentMode)
             }
-        }
+        }.applyModifier(model.modifier)
     }
 
     /// Determines the appropriate URL for the image based on the device's color scheme.

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/AEPStack.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/AEPStack.swift
@@ -22,6 +22,9 @@ public class AEPStack: ObservableObject {
     /// The spacing between child views in the stack.
     @Published public var spacing: CGFloat?
 
+    /// custom view modifier that can be applied to the text view.
+    @Published public var modifier: AEPViewModifier?
+
     /// Adds a view model to the stack.
     /// This method is used internally to
     /// - Parameter model: The view model to be added, conforming to `AEPViewModel`.

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/AEPStack.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/AEPStack.swift
@@ -22,7 +22,7 @@ public class AEPStack: ObservableObject {
     /// The spacing between child views in the stack.
     @Published public var spacing: CGFloat?
 
-    /// custom view modifier that can be applied to the text view.
+    /// custom view modifier that can be applied to the stack view.
     @Published public var modifier: AEPViewModifier?
 
     /// Adds a view model to the stack.

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStackView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStackView.swift
@@ -22,6 +22,6 @@ public struct AEPHStackView: View {
             ForEach(Array(model.childModels.enumerated()), id: \.offset) { _, model in
                 AnyView(model.view)
             }
-        }
+        }.applyModifier(model.modifier)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStackView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStackView.swift
@@ -22,6 +22,6 @@ public struct AEPVStackView: View {
             ForEach(Array(model.childModels.enumerated()), id: \.offset) { _, model in
                 AnyView(model.view)
             }
-        }
+        }.applyModifier(model.modifier)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPText.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPText.swift
@@ -15,14 +15,17 @@ import SwiftUI
 
 // The model class representing the text UI element of the ContentCard.
 public class AEPText: ObservableObject, AEPViewModel {
-    // The content of the text
+    /// The content of the text
     @Published public var content: String
 
-    // The font of the text
+    /// The font of the text
     @Published public var font: Font?
 
-    // The color of the text
+    /// The color of the text
     @Published public var textColor: Color?
+
+    /// A custom view modifier that can be applied to the text view.
+    @Published public var modifier: AEPViewModifier?
 
     /// The SwiftUI view of the text
     public lazy var view: some View = AEPTextView(model: self)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPTextView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPTextView.swift
@@ -27,5 +27,6 @@ public struct AEPTextView: View {
         Text(model.content)
             .font(model.font)
             .foregroundColor(model.textColor)
+            .applyModifier(model.modifier)
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPViewModifier.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPViewModifier.swift
@@ -1,0 +1,35 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import SwiftUI
+
+/// A custom view modifier that wraps and applies other SwiftUI view modifiers.
+///
+/// AEPViewModifier provides a way to encapsulate and store view modifiers,
+/// allowing for dynamic application of modifiers to views.
+public struct AEPViewModifier: ViewModifier {
+    private let _body: (Content) -> any View
+
+    /// Initializes a new `AEPViewModifier` with the given SwiftUI view modifier.
+    public init<M: ViewModifier>(_ modifier: M) {
+        self._body = { content in
+            content.modifier(modifier)
+        }
+    }
+
+    /// Applies the wrapped modifier to the given content.
+    /// This method is called by SwiftUI when the modifier is applied to a view.
+    public func body(content: Content) -> some View {
+        AnyView(_body(content))
+    }
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/View+CustomModifiers.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/View+CustomModifiers.swift
@@ -1,0 +1,40 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import SwiftUI
+
+extension View {
+    /// Applies an optional `AEPViewModifier` to the view.
+    /// - Parameter modifier: An optional `AEPViewModifier` to apply to the view.
+    /// - Returns: A view with the modifier applied if provided, otherwise the original view.
+    @ViewBuilder
+    func applyModifier(_ modifier: AEPViewModifier?) -> some View {
+        applyIf(modifier) { view, mod in
+            view.modifier(mod)
+        }
+    }
+
+    /// Conditionally applies a transformation to the view based on an optional value.
+    /// - Parameters:
+    ///   - value: An optional value that determines whether the transformation should be applied.
+    ///   - apply: A closure that takes the current view and the unwrapped value, and returns a modified view.
+    /// - Returns: A view that is either transformed by the `apply` closure if `value` is non-nil,
+    ///            or the original view if `value` is nil.
+    @ViewBuilder
+    private func applyIf<Value>(_ value: Value?, apply: (Self, Value) -> some View) -> some View {
+        if let value = value {
+            apply(self, value)
+        } else {
+            self
+        }
+    }
+}

--- a/Frameworks/AEPSwiftUI/TestApp/HomePage.swift
+++ b/Frameworks/AEPSwiftUI/TestApp/HomePage.swift
@@ -28,15 +28,16 @@ struct HomePage: View {
                          .frame(width: 325, height: 120)
                          .overlay(
                              RoundedRectangle(cornerRadius: 5)
-                                 .stroke(.gray, lineWidth: 1)
+                                .stroke(Color(.systemGray3), lineWidth: 1)
                          )
                 }
             }
         }
         .padding()
         .onAppear(perform: {
+            
             let homePageSurface = Surface(path: "homepage")
-            AEPSwiftUI.getContentCardsUI(for: homePageSurface,customizer: HomePageCardCustomizer(),{ result in
+            AEPSwiftUI.getContentCardsUI(for: homePageSurface, customizer: HomePageCardCustomizer(),{ result in
                 switch result {
                 case .success(let cards):
                     savedCards = cards
@@ -54,13 +55,19 @@ struct HomePage: View {
 class HomePageCardCustomizer : ContentCardCustomizer {
     
     func customize(template: SmallImageTemplate) {
-        template.rootHStack.spacing = 10
-        template.textVStack.alignment = .leading
-        template.textVStack.spacing = 10
+        
+        // customize UI elements
         template.title.textColor = .primary
         template.body?.textColor = .secondary
         template.body?.font = .subheadline
         template.buttons?.first?.text.font = .system(size: 13)
+        
+        // customize stack structure
+        template.rootHStack.spacing = 10
+        template.textVStack.alignment = .leading
+        template.textVStack.spacing = 10
+        
+        // add custom modifiers
         template.buttonHStack.modifier = AEPViewModifier(ButtonHStackModifier())
         template.rootHStack.modifier = AEPViewModifier(RootHStackModifier())
     }

--- a/Frameworks/AEPSwiftUI/TestApp/HomePage.swift
+++ b/Frameworks/AEPSwiftUI/TestApp/HomePage.swift
@@ -19,12 +19,13 @@ struct HomePage: View {
     @State var savedCards : [ContentCardUI] = []
     
     var body: some View {
+        Spacer()
         Text("Content Cards").font(.title)
-        ScrollView {
-            VStack {
+        ScrollView (.horizontal, showsIndicators: false){
+            LazyHStack(spacing: 20) {
                  ForEach(savedCards) { card in
                      card.view
-                         .frame(height: 150)
+                         .frame(width: 325, height: 120)
                          .overlay(
                              RoundedRectangle(cornerRadius: 5)
                                  .stroke(.gray, lineWidth: 1)
@@ -35,23 +36,9 @@ struct HomePage: View {
         .padding()
         .onAppear(perform: {
             let homePageSurface = Surface(path: "homepage")
-            AEPSwiftUI.getContentCardsUI(for: homePageSurface, { result in
+            AEPSwiftUI.getContentCardsUI(for: homePageSurface,customizer: HomePageCardCustomizer(),{ result in
                 switch result {
                 case .success(let cards):
-                    
-                    // customize each card only if
-                    cards.forEach { card in
-                        
-                        // customize small image template card only
-                        guard let template = card.template as? SmallImageTemplate else {
-                            return
-                        }
-                        template.rootHStack.spacing = 10
-                        template.textVStack.spacing = 10
-                        template.title.textColor = .primary
-                        template.body?.textColor = .secondary
-                        template.body?.font = .subheadline
-                    }
                     savedCards = cards
                     
                 case .failure(let error):
@@ -61,6 +48,36 @@ struct HomePage: View {
             })
         
         })
+    }
+}
+
+class HomePageCardCustomizer : ContentCardCustomizer {
+    
+    func customize(template: SmallImageTemplate) {
+        template.rootHStack.spacing = 10
+        template.textVStack.alignment = .leading
+        template.textVStack.spacing = 10
+        template.title.textColor = .primary
+        template.body?.textColor = .secondary
+        template.body?.font = .subheadline
+        template.buttons?.first?.text.font = .system(size: 13)
+        template.buttonHStack.modifier = AEPViewModifier(ButtonHStackModifier())
+        template.rootHStack.modifier = AEPViewModifier(RootHStackModifier())
+    }
+    
+    struct RootHStackModifier : ViewModifier {
+        func body(content: Content) -> some View {
+             content
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing)
+         }
+    }
+    
+    struct ButtonHStackModifier : ViewModifier {
+        func body(content: Content) -> some View {
+             content
+                .frame(maxWidth: .infinity, alignment: .trailing)
+         }
     }
 }
 


### PR DESCRIPTION
- Edited the public API to accept customizer 
- Implemented AEPViewModifer class - A wrapper over the SwiftUI's protocol ViewModifier
- Expose modifier property (AEPViewModifier) to allow passing ViewModifier for each UIElement
- Edit the test app to use modifiers and ContentCardCustomizer