### PR TITLE
Dismiss Button / Default Styling

### DIFF
--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -70,6 +70,9 @@
 		B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */; };
 		B669EDA42C779E0600A26954 /* View+CustomModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */; };
 		B669EDB22C793B8700A26954 /* EmptyCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */; };
+		B669EDB52C79419800A26954 /* AEPDismissButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB42C79419800A26954 /* AEPDismissButton.swift */; };
+		B669EDB72C7941C200A26954 /* AEPDismissButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */; };
+		B669EDB92C7941E100A26954 /* DismissButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -178,6 +181,9 @@
 		B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPViewModifier.swift; sourceTree = "<group>"; };
 		B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CustomModifiers.swift"; sourceTree = "<group>"; };
 		B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCustomizer.swift; sourceTree = "<group>"; };
+		B669EDB42C79419800A26954 /* AEPDismissButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButton.swift; sourceTree = "<group>"; };
+		B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButtonView.swift; sourceTree = "<group>"; };
+		B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButtonStyle.swift; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -401,6 +407,16 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+		B669EDB32C79417E00A26954 /* AEPDismissButton */ = {
+			isa = PBXGroup;
+			children = (
+				B669EDB42C79419800A26954 /* AEPDismissButton.swift */,
+				B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */,
+				B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */,
+			);
+			path = AEPDismissButton;
+			sourceTree = "<group>";
+		};
 		B6F4D1902C6278AD00376045 /* ContentCards */ = {
 			isa = PBXGroup;
 			children = (
@@ -434,6 +450,7 @@
 				B669ED452C6F2F0E00A26954 /* AEPViewModel.swift */,
 				B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */,
 				B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */,
+				B669EDB32C79417E00A26954 /* AEPDismissButton */,
 				B669ED4B2C6F3BC400A26954 /* AEPStack */,
 				B669ED1D2C6AE0B200A26954 /* AEPImage */,
 				B669ED162C6AC7A500A26954 /* AEPButton */,
@@ -711,6 +728,7 @@
 				B669ED572C70029000A26954 /* ContentCardSchemaData+TemplateContent.swift in Sources */,
 				B669ED1F2C6AE0D500A26954 /* AEPImageView.swift in Sources */,
 				B669EDA42C779E0600A26954 /* View+CustomModifiers.swift in Sources */,
+				B669EDB52C79419800A26954 /* AEPDismissButton.swift in Sources */,
 				B6F4D1A02C62935000376045 /* AEPImage.swift in Sources */,
 				B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */,
 				B669ED212C6AEB7D00A26954 /* ImageSourceType.swift in Sources */,
@@ -718,6 +736,7 @@
 				B669ED4D2C6F3BE900A26954 /* AEPStack.swift in Sources */,
 				B669EDA02C771E2D00A26954 /* ContentCardCustomizable.swift in Sources */,
 				B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */,
+				B669EDB72C7941C200A26954 /* AEPDismissButtonView.swift in Sources */,
 				B6F4D1A42C62947F00376045 /* SmallImageTemplate.swift in Sources */,
 				B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */,
 				B669ED702C71DE2300A26954 /* ContentCardTemplate.swift in Sources */,
@@ -726,6 +745,7 @@
 				B669ED4A2C6F355F00A26954 /* AEPVStackView.swift in Sources */,
 				B669ED272C6D3B4E00A26954 /* AEPHStack.swift in Sources */,
 				B669ED462C6F2F0E00A26954 /* AEPViewModel.swift in Sources */,
+				B669EDB92C7941E100A26954 /* DismissButtonStyle.swift in Sources */,
 				B669ED522C6FDF2800A26954 /* AEPStackError.swift in Sources */,
 				B669ED7D2C750D8E00A26954 /* ContentCardUI+EventHandler.swift in Sources */,
 				B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */,

--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -66,7 +66,7 @@
 		B669ED982C75951D00A26954 /* MockTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED972C75951D00A26954 /* MockTemplate.swift */; };
 		B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED992C76655300A26954 /* ContentCardUIError.swift */; };
 		B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */; };
-		B669EDA02C771E2D00A26954 /* ContentCardCustomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9F2C771E2D00A26954 /* ContentCardCustomizable.swift */; };
+		B669EDA02C771E2D00A26954 /* ContentCardCustomizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9F2C771E2D00A26954 /* ContentCardCustomizing.swift */; };
 		B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */; };
 		B669EDA42C779E0600A26954 /* View+CustomModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */; };
 		B669EDB22C793B8700A26954 /* EmptyCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */; };
@@ -181,7 +181,7 @@
 		B669ED972C75951D00A26954 /* MockTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemplate.swift; sourceTree = "<group>"; };
 		B669ED992C76655300A26954 /* ContentCardUIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUIError.swift; sourceTree = "<group>"; };
 		B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateBuilder.swift; sourceTree = "<group>"; };
-		B669ED9F2C771E2D00A26954 /* ContentCardCustomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCustomizable.swift; sourceTree = "<group>"; };
+		B669ED9F2C771E2D00A26954 /* ContentCardCustomizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCustomizing.swift; sourceTree = "<group>"; };
 		B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPViewModifier.swift; sourceTree = "<group>"; };
 		B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CustomModifiers.swift"; sourceTree = "<group>"; };
 		B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCustomizer.swift; sourceTree = "<group>"; };
@@ -439,7 +439,7 @@
 				B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */,
 				B669ED552C6FE92E00A26954 /* ContentCardSchemaData+TemplateContent.swift */,
 				B669ED992C76655300A26954 /* ContentCardUIError.swift */,
-				B669ED9F2C771E2D00A26954 /* ContentCardCustomizable.swift */,
+				B669ED9F2C771E2D00A26954 /* ContentCardCustomizing.swift */,
 			);
 			path = ContentCards;
 			sourceTree = "<group>";
@@ -746,7 +746,7 @@
 				B669ED212C6AEB7D00A26954 /* ImageSourceType.swift in Sources */,
 				B669ED7B2C75087B00A26954 /* TemplateEventHandler.swift in Sources */,
 				B669ED4D2C6F3BE900A26954 /* AEPStack.swift in Sources */,
-				B669EDA02C771E2D00A26954 /* ContentCardCustomizable.swift in Sources */,
+				B669EDA02C771E2D00A26954 /* ContentCardCustomizing.swift in Sources */,
 				B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */,
 				B669EDB72C7941C200A26954 /* AEPDismissButtonView.swift in Sources */,
 				B6F4D1A42C62947F00376045 /* SmallImageTemplate.swift in Sources */,

--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -66,9 +66,10 @@
 		B669ED982C75951D00A26954 /* MockTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED972C75951D00A26954 /* MockTemplate.swift */; };
 		B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED992C76655300A26954 /* ContentCardUIError.swift */; };
 		B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */; };
-		B669EDA02C771E2D00A26954 /* ContentCardCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9F2C771E2D00A26954 /* ContentCardCustomizer.swift */; };
+		B669EDA02C771E2D00A26954 /* ContentCardCustomizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669ED9F2C771E2D00A26954 /* ContentCardCustomizable.swift */; };
 		B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */; };
 		B669EDA42C779E0600A26954 /* View+CustomModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */; };
+		B669EDB22C793B8700A26954 /* EmptyCustomizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -173,9 +174,10 @@
 		B669ED972C75951D00A26954 /* MockTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockTemplate.swift; sourceTree = "<group>"; };
 		B669ED992C76655300A26954 /* ContentCardUIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUIError.swift; sourceTree = "<group>"; };
 		B669ED9D2C76AA0700A26954 /* TemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateBuilder.swift; sourceTree = "<group>"; };
-		B669ED9F2C771E2D00A26954 /* ContentCardCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCustomizer.swift; sourceTree = "<group>"; };
+		B669ED9F2C771E2D00A26954 /* ContentCardCustomizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardCustomizable.swift; sourceTree = "<group>"; };
 		B669EDA12C778F4C00A26954 /* AEPViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPViewModifier.swift; sourceTree = "<group>"; };
 		B669EDA32C779E0600A26954 /* View+CustomModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CustomModifiers.swift"; sourceTree = "<group>"; };
+		B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCustomizer.swift; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -371,6 +373,7 @@
 			isa = PBXGroup;
 			children = (
 				B669ED972C75951D00A26954 /* MockTemplate.swift */,
+				B669EDB12C793B8700A26954 /* EmptyCustomizer.swift */,
 				B669ED5E2C703F9B00A26954 /* FileReader.swift */,
 				B669ED612C7075A700A26954 /* ContentCardTestUtil.swift */,
 			);
@@ -408,7 +411,7 @@
 				B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */,
 				B669ED552C6FE92E00A26954 /* ContentCardSchemaData+TemplateContent.swift */,
 				B669ED992C76655300A26954 /* ContentCardUIError.swift */,
-				B669ED9F2C771E2D00A26954 /* ContentCardCustomizer.swift */,
+				B669ED9F2C771E2D00A26954 /* ContentCardCustomizable.swift */,
 			);
 			path = ContentCards;
 			sourceTree = "<group>";
@@ -713,7 +716,7 @@
 				B669ED212C6AEB7D00A26954 /* ImageSourceType.swift in Sources */,
 				B669ED7B2C75087B00A26954 /* TemplateEventHandler.swift in Sources */,
 				B669ED4D2C6F3BE900A26954 /* AEPStack.swift in Sources */,
-				B669EDA02C771E2D00A26954 /* ContentCardCustomizer.swift in Sources */,
+				B669EDA02C771E2D00A26954 /* ContentCardCustomizable.swift in Sources */,
 				B669ED9A2C76655300A26954 /* ContentCardUIError.swift in Sources */,
 				B6F4D1A42C62947F00376045 /* SmallImageTemplate.swift in Sources */,
 				B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */,
@@ -743,6 +746,7 @@
 				B669ED982C75951D00A26954 /* MockTemplate.swift in Sources */,
 				B669ED622C7075A700A26954 /* ContentCardTestUtil.swift in Sources */,
 				B669ED642C71C54700A26954 /* SmallImageTemplateTests.swift in Sources */,
+				B669EDB22C793B8700A26954 /* EmptyCustomizer.swift in Sources */,
 				B669ED792C7419AA00A26954 /* ContentCardTemplateTypeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -74,6 +74,9 @@
 		B669EDB72C7941C200A26954 /* AEPDismissButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */; };
 		B669EDB92C7941E100A26954 /* DismissButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */; };
 		B669EDBB2C7B7C0A00A26954 /* AEPTextType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDBA2C7B7C0A00A26954 /* AEPTextType.swift */; };
+		B669EDBE2C7C37A900A26954 /* AEPTextTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDBC2C7C377800A26954 /* AEPTextTypeTests.swift */; };
+		B669EDC02C7C3D1D00A26954 /* DismissButtonStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDBF2C7C3D1D00A26954 /* DismissButtonStyleTests.swift */; };
+		B669EDC22C7C415700A26954 /* AEPDismissButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDC12C7C415700A26954 /* AEPDismissButtonTests.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -186,6 +189,9 @@
 		B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButtonView.swift; sourceTree = "<group>"; };
 		B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButtonStyle.swift; sourceTree = "<group>"; };
 		B669EDBA2C7B7C0A00A26954 /* AEPTextType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPTextType.swift; sourceTree = "<group>"; };
+		B669EDBC2C7C377800A26954 /* AEPTextTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPTextTypeTests.swift; sourceTree = "<group>"; };
+		B669EDBF2C7C3D1D00A26954 /* DismissButtonStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButtonStyleTests.swift; sourceTree = "<group>"; };
+		B669EDC12C7C415700A26954 /* AEPDismissButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButtonTests.swift; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -294,9 +300,12 @@
 				B669ED1B2C6AD37E00A26954 /* AEPTextTests.swift */,
 				B669ED232C6B010B00A26954 /* AEPImageTests.swift */,
 				B669ED4E2C6F3DE400A26954 /* AEPStackTests.swift */,
+				B669EDBC2C7C377800A26954 /* AEPTextTypeTests.swift */,
 				B669ED782C7419AA00A26954 /* ContentCardTemplateTypeTests.swift */,
 				B669ED582C700B9800A26954 /* ContentCardSchemaData+TemplateContentTests.swift */,
 				B669ED632C71C54700A26954 /* SmallImageTemplateTests.swift */,
+				B669EDBF2C7C3D1D00A26954 /* DismissButtonStyleTests.swift */,
+				B669EDC12C7C415700A26954 /* AEPDismissButtonTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -760,8 +769,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B669EDC02C7C3D1D00A26954 /* DismissButtonStyleTests.swift in Sources */,
 				B669ED1A2C6AD2FF00A26954 /* AEPButtonTests.swift in Sources */,
 				B669ED592C700B9800A26954 /* ContentCardSchemaData+TemplateContentTests.swift in Sources */,
+				B669EDBE2C7C37A900A26954 /* AEPTextTypeTests.swift in Sources */,
 				B669ED5F2C703F9B00A26954 /* FileReader.swift in Sources */,
 				B669ED1C2C6AD37E00A26954 /* AEPTextTests.swift in Sources */,
 				B669ED242C6B010B00A26954 /* AEPImageTests.swift in Sources */,
@@ -771,6 +782,7 @@
 				B669ED622C7075A700A26954 /* ContentCardTestUtil.swift in Sources */,
 				B669ED642C71C54700A26954 /* SmallImageTemplateTests.swift in Sources */,
 				B669EDB22C793B8700A26954 /* EmptyCustomizer.swift in Sources */,
+				B669EDC22C7C415700A26954 /* AEPDismissButtonTests.swift in Sources */,
 				B669ED792C7419AA00A26954 /* ContentCardTemplateTypeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		B669EDBE2C7C37A900A26954 /* AEPTextTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDBC2C7C377800A26954 /* AEPTextTypeTests.swift */; };
 		B669EDC02C7C3D1D00A26954 /* DismissButtonStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDBF2C7C3D1D00A26954 /* DismissButtonStyleTests.swift */; };
 		B669EDC22C7C415700A26954 /* AEPDismissButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDC12C7C415700A26954 /* AEPDismissButtonTests.swift */; };
+		B669EDC52C7D0C8100A26954 /* ContentCardUIEventListening.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDC42C7D0C8100A26954 /* ContentCardUIEventListening.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -192,6 +193,7 @@
 		B669EDBC2C7C377800A26954 /* AEPTextTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPTextTypeTests.swift; sourceTree = "<group>"; };
 		B669EDBF2C7C3D1D00A26954 /* DismissButtonStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButtonStyleTests.swift; sourceTree = "<group>"; };
 		B669EDC12C7C415700A26954 /* AEPDismissButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButtonTests.swift; sourceTree = "<group>"; };
+		B669EDC42C7D0C8100A26954 /* ContentCardUIEventListening.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUIEventListening.swift; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -435,11 +437,12 @@
 				B6F4D1972C62834000376045 /* Template */,
 				B6F4D1982C62834E00376045 /* UIElement */,
 				B6F4D18E2C62735600376045 /* ContentCardUI.swift */,
+				B669ED9F2C771E2D00A26954 /* ContentCardCustomizing.swift */,
+				B669EDC42C7D0C8100A26954 /* ContentCardUIEventListening.swift */,
 				B669ED7C2C750D8E00A26954 /* ContentCardUI+EventHandler.swift */,
 				B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */,
 				B669ED552C6FE92E00A26954 /* ContentCardSchemaData+TemplateContent.swift */,
 				B669ED992C76655300A26954 /* ContentCardUIError.swift */,
-				B669ED9F2C771E2D00A26954 /* ContentCardCustomizing.swift */,
 			);
 			path = ContentCards;
 			sourceTree = "<group>";
@@ -755,6 +758,7 @@
 				B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */,
 				B669EDBB2C7B7C0A00A26954 /* AEPTextType.swift in Sources */,
 				B669ED482C6F353E00A26954 /* AEPVStack.swift in Sources */,
+				B669EDC52C7D0C8100A26954 /* ContentCardUIEventListening.swift in Sources */,
 				B669ED4A2C6F355F00A26954 /* AEPVStackView.swift in Sources */,
 				B669ED272C6D3B4E00A26954 /* AEPHStack.swift in Sources */,
 				B669ED462C6F2F0E00A26954 /* AEPViewModel.swift in Sources */,

--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		B669EDB52C79419800A26954 /* AEPDismissButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB42C79419800A26954 /* AEPDismissButton.swift */; };
 		B669EDB72C7941C200A26954 /* AEPDismissButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */; };
 		B669EDB92C7941E100A26954 /* DismissButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */; };
+		B669EDBB2C7B7C0A00A26954 /* AEPTextType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B669EDBA2C7B7C0A00A26954 /* AEPTextType.swift */; };
 		B6F4D18F2C62735600376045 /* ContentCardUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D18E2C62735600376045 /* ContentCardUI.swift */; };
 		B6F4D1942C6279C300376045 /* ContentCardTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */; };
 		B6F4D19C2C628FFF00376045 /* AEPText.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4D19B2C628FFF00376045 /* AEPText.swift */; };
@@ -184,6 +185,7 @@
 		B669EDB42C79419800A26954 /* AEPDismissButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButton.swift; sourceTree = "<group>"; };
 		B669EDB62C7941C200A26954 /* AEPDismissButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPDismissButtonView.swift; sourceTree = "<group>"; };
 		B669EDB82C7941E100A26954 /* DismissButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissButtonStyle.swift; sourceTree = "<group>"; };
+		B669EDBA2C7B7C0A00A26954 /* AEPTextType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPTextType.swift; sourceTree = "<group>"; };
 		B6F4D18E2C62735600376045 /* ContentCardUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardUI.swift; sourceTree = "<group>"; };
 		B6F4D1932C6279C300376045 /* ContentCardTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCardTemplateType.swift; sourceTree = "<group>"; };
 		B6F4D19B2C628FFF00376045 /* AEPText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AEPText.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 			children = (
 				B6F4D19B2C628FFF00376045 /* AEPText.swift */,
 				B669ED142C6ABF6200A26954 /* AEPTextView.swift */,
+				B669EDBA2C7B7C0A00A26954 /* AEPTextType.swift */,
 			);
 			path = AEPText;
 			sourceTree = "<group>";
@@ -741,6 +744,7 @@
 				B669ED9E2C76AA0700A26954 /* TemplateBuilder.swift in Sources */,
 				B669ED702C71DE2300A26954 /* ContentCardTemplate.swift in Sources */,
 				B669EDA22C778F4C00A26954 /* AEPViewModifier.swift in Sources */,
+				B669EDBB2C7B7C0A00A26954 /* AEPTextType.swift in Sources */,
 				B669ED482C6F353E00A26954 /* AEPVStack.swift in Sources */,
 				B669ED4A2C6F355F00A26954 /* AEPVStackView.swift in Sources */,
 				B669ED272C6D3B4E00A26954 /* AEPHStack.swift in Sources */,

--- a/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/xcshareddata/xcschemes/AEPSwiftUITestApp.xcscheme
+++ b/Frameworks/AEPSwiftUI/AEPSwiftUI.xcodeproj/xcshareddata/xcschemes/AEPSwiftUITestApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
@@ -16,8 +16,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B669ED812C75403200A26954"
-               BuildableName = "TestApp.app"
-               BlueprintName = "TestApp"
+               BuildableName = "AEPSwiftUITestApp.app"
+               BlueprintName = "AEPSwiftUITestApp"
                ReferencedContainer = "container:AEPSwiftUI.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -45,8 +45,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B669ED812C75403200A26954"
-            BuildableName = "TestApp.app"
-            BlueprintName = "TestApp"
+            BuildableName = "AEPSwiftUITestApp.app"
+            BlueprintName = "AEPSwiftUITestApp"
             ReferencedContainer = "container:AEPSwiftUI.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -62,8 +62,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B669ED812C75403200A26954"
-            BuildableName = "TestApp.app"
-            BlueprintName = "TestApp"
+            BuildableName = "AEPSwiftUITestApp.app"
+            BlueprintName = "AEPSwiftUITestApp"
             ReferencedContainer = "container:AEPSwiftUI.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
@@ -27,7 +27,7 @@ public class AEPSwiftUI: NSObject {
     ///     - success([ContentCardUI]):  An array of `ContentCardUI` objects if the operation is successful.
     ///     - failure(Error) : An error indicating the failure reason
     public static func getContentCardsUI(for surface: Surface,
-                                         customizer: ContentCardCustomizable? = nil,
+                                         customizer: ContentCardCustomizing? = nil,
                                          _ completion: @escaping (Result<[ContentCardUI], Error>) -> Void) {
         // Request propositions for the specified surface from Messaging extension.
         Messaging.getPropositionsForSurfaces([surface]) { propositionDict, error in

--- a/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
@@ -22,12 +22,12 @@ public class AEPSwiftUI: NSObject {
     /// Retrieves the content cards UI for a given surface.
     /// - Parameters:
     ///   - surface: The surface for which to retrieve the content cards.
-    ///   - customizer: An optional ContentCardCustomizer object to customize the appearance of the content card template.
+    ///   - customizer: An optional ContentCardCustomizable object to customize the appearance of the content card template.
     ///   - completion: A completion handler that is called with a `Result` type containing either:
     ///     - success([ContentCardUI]):  An array of `ContentCardUI` objects if the operation is successful.
     ///     - failure(Error) : An error indicating the failure reason
     public static func getContentCardsUI(for surface: Surface,
-                                         customizer: ContentCardCustomizer? = nil,
+                                         customizer: ContentCardCustomizable? = nil,
                                          _ completion: @escaping (Result<[ContentCardUI], Error>) -> Void) {
         // Request propositions for the specified surface from Messaging extension.
         Messaging.getPropositionsForSurfaces([surface]) { propositionDict, error in

--- a/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/AEPSwiftUI+PublicAPI.swift
@@ -23,11 +23,13 @@ public class AEPSwiftUI: NSObject {
     /// - Parameters:
     ///   - surface: The surface for which to retrieve the content cards.
     ///   - customizer: An optional ContentCardCustomizable object to customize the appearance of the content card template.
+    ///   - listener: An optional ContentCardUIEventListening object to listen to UI events from the content card.
     ///   - completion: A completion handler that is called with a `Result` type containing either:
     ///     - success([ContentCardUI]):  An array of `ContentCardUI` objects if the operation is successful.
     ///     - failure(Error) : An error indicating the failure reason
     public static func getContentCardsUI(for surface: Surface,
                                          customizer: ContentCardCustomizing? = nil,
+                                         listener: ContentCardUIEventListening? = nil,
                                          _ completion: @escaping (Result<[ContentCardUI], Error>) -> Void) {
         // Request propositions for the specified surface from Messaging extension.
         Messaging.getPropositionsForSurfaces([surface]) { propositionDict, error in
@@ -50,7 +52,8 @@ public class AEPSwiftUI: NSObject {
             for proposition in propositions {
                 // attempt to create a ContentCardUI instance with the schema data.
                 guard let contentCard = ContentCardUI.createInstance(with: proposition,
-                                                                     customizer: customizer) else {
+                                                                     customizer: customizer,
+                                                                     listener: listener) else {
                     Log.warning(label: Constants.LOG_TAG,
                                 "Failed to create ContentCardUI for proposition with ID: \(proposition.uniqueId)")
                     continue

--- a/Frameworks/AEPSwiftUI/Sources/Constants.swift
+++ b/Frameworks/AEPSwiftUI/Sources/Constants.swift
@@ -11,6 +11,7 @@
  */
 
 import Foundation
+import SwiftUI
 
 enum Constants {
     static let LOG_TAG = "AEPSwiftUI"
@@ -20,6 +21,35 @@ enum Constants {
         static let SmallImage = "SmallImage"
         static let LargeImage = "LargeImage"
         static let ImageOnly = "ImageOnly"
+
+        enum DefaultStyle {
+            enum Text {
+                static let TITLE_FONT = Font.system(size: 15, weight: .medium)
+                static let TITLE_COLOR = Color.primary
+
+                static let BODY_FONT = Font.system(size: 13, weight: .regular)
+                static let BODY_COLOR = Color.secondary
+
+                static let BUTTON_FONT = Font.system(size: 13, weight: .regular)
+                static let BUTTON_COLOR = Color.blue
+            }
+
+            enum Stack {
+                static let SPACING = 8.0
+                static let HORIZONTAL_ALIGNMENT = HorizontalAlignment.center
+                static let VERTICAL_ALIGNMENT = VerticalAlignment.center
+            }
+
+            enum Image {
+                static let ICON_COLOR = Color.primary
+                static let ICON_SIZE = 13
+            }
+
+            enum DismissButton {
+                static let ALIGNMENT = Alignment.topTrailing
+                static let SIZE = 13
+            }
+        }
 
         enum InteractionID {
             // TODO: Verify with PM to see if this Interaction event name makes sense of all platforms

--- a/Frameworks/AEPSwiftUI/Sources/Constants.swift
+++ b/Frameworks/AEPSwiftUI/Sources/Constants.swift
@@ -23,6 +23,7 @@ enum Constants {
         static let ImageOnly = "ImageOnly"
 
         enum DefaultStyle {
+            static let PADDING = 8.0
             enum Text {
                 static let TITLE_FONT = Font.system(size: 15, weight: .medium)
                 static let TITLE_COLOR = Color.primary

--- a/Frameworks/AEPSwiftUI/Sources/Constants.swift
+++ b/Frameworks/AEPSwiftUI/Sources/Constants.swift
@@ -37,6 +37,16 @@ enum Constants {
             static let IMAGE = "image"
             static let ACTION_URL = "actionUrl"
             static let BUTTONS = "buttons"
+            static let DISMISS_BTN = "dismissBtn"
+        }
+
+        enum DismissButton {
+            static let STYLE = "style"
+
+            enum Icon {
+                static let SIMPLE = "xmark"
+                static let CIRCLE = "xmark.circle.fill"
+            }
         }
 
         enum UIElement {
@@ -55,6 +65,7 @@ enum Constants {
                 static let DARK_URL = "darkUrl"
                 static let BUNDLE = "bundle"
                 static let DARK_BUNDLE = "darkBundle"
+                static let ICON = "icon"
             }
         }
     }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizable.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizable.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Protocol for customizing Content Card templates
-public protocol ContentCardCustomizer {
+public protocol ContentCardCustomizable {
     /// Implement this function to customize content cards with SmallImageTemplate
     func customize(template: SmallImageTemplate)
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizing.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardCustomizing.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 /// Protocol for customizing Content Card templates
-public protocol ContentCardCustomizable {
+public protocol ContentCardCustomizing {
     /// Implement this function to customize content cards with SmallImageTemplate
     func customize(template: SmallImageTemplate)
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardSchemaData+TemplateContent.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardSchemaData+TemplateContent.swift
@@ -32,7 +32,7 @@ extension ContentCardSchemaData {
             return nil
         }
 
-        return AEPText(titleData)
+        return AEPText(titleData, type: .title)
     }
 
     /// This property extracts the body data from the content dictionary and attempts to
@@ -41,7 +41,7 @@ extension ContentCardSchemaData {
         guard let bodyData = contentDict?[Constants.CardTemplate.SchemaData.BODY] as? [String: Any] else {
             return nil
         }
-        return AEPText(bodyData)
+        return AEPText(bodyData, type: .body)
     }
 
     /// This property extracts the image data from the content dictionary and attempts to

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardSchemaData+TemplateContent.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardSchemaData+TemplateContent.swift
@@ -64,6 +64,19 @@ extension ContentCardSchemaData {
         return buttonsData.compactMap { AEPButton($0, template) }
     }
 
+    /// Retrieves the dismiss button configuration for a given content card template.
+    /// This method extracts the dismiss button data from the content dictionary and creates an instance of `AEPDismissButton` if the data is present. If the dismiss button data is not found, it returns `nil`.
+    /// - Parameters:
+    ///  - template: The `ContentCardTemplate` instance for which the dismiss button is initialized.
+    /// - Returns: An AEPDismissButton instance, or nil if the data is not available.
+    func getDismissButton(forTemplate template: any ContentCardTemplate) -> AEPDismissButton? {
+        guard let dismissButtonData = contentDict?[Constants.CardTemplate.SchemaData.DISMISS_BTN] as? [String: Any] else {
+            return nil
+        }
+
+        return AEPDismissButton(dismissButtonData, template)
+    }
+
     /// This property extracts the action URL from the content dictionary and returns it as a URL object.
     /// Returns `nil` if the action URL is not available or if it is not a valid URL.
     var actionUrl: URL? {

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI+EventHandler.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI+EventHandler.swift
@@ -11,20 +11,29 @@
  */
 
 import Foundation
+import UIKit
 
 extension ContentCardUI: TemplateEventHandler {
     /// Called when the templated content card is displayed to the user.
     func onDisplay() {
         proposition.items.first?.contentCardSchemaData?.track(withEdgeEventType: .display)
+        listener?.onDisplay(self)
     }
 
     /// Called when the templated content card is displayed to the user.
     func onDismiss() {
         proposition.items.first?.contentCardSchemaData?.track(withEdgeEventType: .dismiss)
+        listener?.onDismiss(self)
     }
 
     /// Called when the templated content card is interacted by the user
-    func onInteract(interactionId: String, actionURL _: URL?) {
+    func onInteract(interactionId: String, actionURL url: URL?) {
         proposition.items.first?.contentCardSchemaData?.track(interactionId, withEdgeEventType: .interact)
+        let urlHandled = listener?.onInteract(self, interactionId, actionURL: url) ?? false
+
+        // Open the URL if available and not handled by the listener
+        if let url = url, !urlHandled {
+            UIApplication.shared.open(url)
+        }
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
@@ -23,10 +23,8 @@ public class ContentCardUI: Identifiable {
     public let template: any ContentCardTemplate
 
     /// SwiftUI view that represents the content card
-    public lazy var view: some View = {
-        // TODO: Make adjustments to remove AnyView
-        AnyView(template.view)
-    }()
+    /// TODO: Make adjustments to remove AnyView
+    public lazy var view: some View = AnyView(template.view)
 
     /// Factory method to create a `ContentCardUI` instance based on the provided schema data.
     /// - Parameters:

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
@@ -29,11 +29,11 @@ public class ContentCardUI: Identifiable {
     /// Factory method to create a `ContentCardUI` instance based on the provided schema data.
     /// - Parameters:
     ///    - proposition: The `Proposition` containing content card template information
-    ///    - customizer: An object conforming to `ContentCardUICustomizer` protocol that allows for
+    ///    - customizer: An object conforming to `ContentCardCustomizing` protocol that allows for
     ///                 custom styling of the content card
     /// - Returns: An initialized `ContentCardUI` instance, or `nil` if unable to create template from proposition
     static func createInstance(with proposition: Proposition,
-                               customizer: ContentCardCustomizable?) -> ContentCardUI? {
+                               customizer: ContentCardCustomizing?) -> ContentCardUI? {
         guard let schemaData = proposition.items.first?.contentCardSchemaData else {
             return nil
         }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
@@ -20,7 +20,11 @@ public class ContentCardUI: Identifiable {
     /// The underlying data model for the content card.
     let proposition: Proposition
 
+    /// The template that defines the content card
     public let template: any ContentCardTemplate
+
+    /// The host app listener for the content card UI events.
+    let listener: ContentCardUIEventListening?
 
     /// SwiftUI view that represents the content card
     /// TODO: Make adjustments to remove AnyView
@@ -29,11 +33,12 @@ public class ContentCardUI: Identifiable {
     /// Factory method to create a `ContentCardUI` instance based on the provided schema data.
     /// - Parameters:
     ///    - proposition: The `Proposition` containing content card template information
-    ///    - customizer: An object conforming to `ContentCardCustomizing` protocol that allows for
-    ///                 custom styling of the content card
+    ///    - customizer: An optional object conforming to `ContentCardCustomizing` protocol that allows for custom styling of the content card
+    ///    - listener: An optional object conforming to `ContentCardUIEventListening` protocol implemented by the host app to listen to UI events from the content card
     /// - Returns: An initialized `ContentCardUI` instance, or `nil` if unable to create template from proposition
     static func createInstance(with proposition: Proposition,
-                               customizer: ContentCardCustomizing?) -> ContentCardUI? {
+                               customizer: ContentCardCustomizing?,
+                               listener: ContentCardUIEventListening?) -> ContentCardUI? {
         guard let schemaData = proposition.items.first?.contentCardSchemaData else {
             return nil
         }
@@ -43,7 +48,7 @@ public class ContentCardUI: Identifiable {
         }
 
         // Initialize the ContentCardUI with the proposition and template
-        let contentCardUI = ContentCardUI(proposition, template)
+        let contentCardUI = ContentCardUI(proposition, template, listener)
 
         // set the listener for the template
         template.eventHandler = contentCardUI
@@ -55,8 +60,9 @@ public class ContentCardUI: Identifiable {
     ///   - proposition: The `Proposition` containing the content card template's information
     ///   - template: The template that defines the content card's layout and behavior.
     /// - Note : This initializer is private to ensure that `ContentCardUI` instances are only created through the `createInstance` factory method.
-    private init(_ proposition: Proposition, _ template: any ContentCardTemplate) {
+    private init(_ proposition: Proposition, _ template: any ContentCardTemplate, _ listener: ContentCardUIEventListening?) {
         self.proposition = proposition
         self.template = template
+        self.listener = listener
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUI.swift
@@ -35,7 +35,7 @@ public class ContentCardUI: Identifiable {
     ///                 custom styling of the content card
     /// - Returns: An initialized `ContentCardUI` instance, or `nil` if unable to create template from proposition
     static func createInstance(with proposition: Proposition,
-                               customizer: ContentCardCustomizer?) -> ContentCardUI? {
+                               customizer: ContentCardCustomizable?) -> ContentCardUI? {
         guard let schemaData = proposition.items.first?.contentCardSchemaData else {
             return nil
         }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUIEventListening.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/ContentCardUIEventListening.swift
@@ -1,0 +1,33 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+public protocol ContentCardUIEventListening {
+    /// Called when the templated content card appears on the screen
+    func onDisplay(_ card: ContentCardUI)
+
+    /// Called when the dismiss button is tapped on templated content card
+    func onDismiss(_ card: ContentCardUI)
+
+    /// Called when the user interacts with the templated content card.
+    /// The boolean return value determines how the interaction is handled:
+    /// Return `true` if the client app has handled the actionURL associated with the interaction
+    /// Return `false` if the SDK should handle the actionURL.
+    ///
+    /// - Parameters:
+    ///   - card: The ContentCardUI instance that was interacted with.
+    ///   - interactionId: A string identifier for the interaction event.
+    ///   - actionURL: An optional URL associated with the interaction.
+    /// - Returns: A boolean indicating whether the interaction was handled.
+    func onInteract(_ card: ContentCardUI, _ interactionId: String, actionURL: URL?) -> Bool
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
@@ -28,6 +28,7 @@ public class BaseTemplate: ObservableObject {
     /// Use this property to set the background color for the content card.
     @Published public var backgroundColor: Color?
 
+    /// the dismiss button model
     @Published public var dismissButton: AEPDismissButton?
 
     /// An optional handler that conforms to the `TemplateEventHandler` protocol.
@@ -66,7 +67,7 @@ public class BaseTemplate: ObservableObject {
                 Constants.CardTemplate.DefaultStyle.DismissButton.ALIGNMENT, content: {
                     if dismissButton != nil {
                         dismissButton?.view
-                            .padding(8)
+                            .padding(Constants.CardTemplate.DefaultStyle.PADDING)
                     }
                 })
     }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
@@ -62,11 +62,12 @@ public class BaseTemplate: ObservableObject {
                     self.isDisplayed = true
                     self.eventHandler?.onDisplay()
                 }
-            }).overlay(alignment: self.dismissButton?.alignment ?? .topTrailing, content: {
-                if dismissButton != nil {
-                    dismissButton?.view
-                        .padding(8)
-                }
-            })
+            }).overlay(alignment: self.dismissButton?.alignment ??
+                Constants.CardTemplate.DefaultStyle.DismissButton.ALIGNMENT, content: {
+                    if dismissButton != nil {
+                        dismissButton?.view
+                            .padding(8)
+                    }
+                })
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/BaseTemplate.swift
@@ -28,6 +28,8 @@ public class BaseTemplate: ObservableObject {
     /// Use this property to set the background color for the content card.
     @Published public var backgroundColor: Color?
 
+    @Published public var dismissButton: AEPDismissButton?
+
     /// An optional handler that conforms to the `TemplateEventHandler` protocol.
     /// Use this property to assign a listener that will handle events related to the content card's interactions.
     weak var eventHandler: TemplateEventHandler?
@@ -59,6 +61,11 @@ public class BaseTemplate: ObservableObject {
                 if !self.isDisplayed {
                     self.isDisplayed = true
                     self.eventHandler?.onDisplay()
+                }
+            }).overlay(alignment: self.dismissButton?.alignment ?? .topTrailing, content: {
+                if dismissButton != nil {
+                    dismissButton?.view
+                        .padding(8)
                 }
             })
     }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
@@ -60,7 +60,7 @@ public class SmallImageTemplate: BaseTemplate, ContentCardTemplate {
     ///    - customizer: An object conforming to ContentCardUICustomizer protocol that allows for
     ///                 custom styling of the content card
     /// - Returns: An initialized `SmallImageTemplate` or `nil` if the required title is missing.
-    init?(_ schemaData: ContentCardSchemaData, _ customizer: ContentCardCustomizer?) {
+    init?(_ schemaData: ContentCardSchemaData, _ customizer: ContentCardCustomizable?) {
         guard let title = schemaData.title else {
             return nil
         }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
@@ -70,6 +70,7 @@ public class SmallImageTemplate: BaseTemplate, ContentCardTemplate {
         self.body = schemaData.body
         self.image = schemaData.image
         self.buttons = schemaData.getButtons(forTemplate: self)
+        self.dismissButton = schemaData.getDismissButton(forTemplate: self)
 
         // Add buttons to buttonHStack
         if let buttons = buttons {

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/SmallImageTemplate.swift
@@ -57,10 +57,10 @@ public class SmallImageTemplate: BaseTemplate, ContentCardTemplate {
     ///
     /// - Parameters:
     ///    - schemaData: The schema data used to populate the template's properties.
-    ///    - customizer: An object conforming to ContentCardUICustomizer protocol that allows for
+    ///    - customizer: An object conforming to ContentCardCustomizing protocol that allows for
     ///                 custom styling of the content card
     /// - Returns: An initialized `SmallImageTemplate` or `nil` if the required title is missing.
-    init?(_ schemaData: ContentCardSchemaData, _ customizer: ContentCardCustomizable?) {
+    init?(_ schemaData: ContentCardSchemaData, _ customizer: ContentCardCustomizing?) {
         guard let title = schemaData.title else {
             return nil
         }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
@@ -19,11 +19,11 @@ enum TemplateBuilder {
     ///
     /// - Parameters:
     ///    - schemaData: The content card schema data containing template information.
-    ///    - customizer: An object conforming to `ContentCardUICustomizer` protocol that allows for
+    ///    - customizer: An object conforming to `ContentCardCustomizing` protocol that allows for
     ///                 custom styling of the content card
     /// - Returns: An instance conforming to `ContentCardTemplate` if a supported template type is found, otherwise `nil`.
     static func buildTemplate(from schemaData: ContentCardSchemaData,
-                              customizer: ContentCardCustomizable?) -> (any ContentCardTemplate)? {
+                              customizer: ContentCardCustomizing?) -> (any ContentCardTemplate)? {
         switch schemaData.templateType {
         case .smallImage:
             return SmallImageTemplate(schemaData, customizer)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/Template/TemplateBuilder.swift
@@ -23,7 +23,7 @@ enum TemplateBuilder {
     ///                 custom styling of the content card
     /// - Returns: An instance conforming to `ContentCardTemplate` if a supported template type is found, otherwise `nil`.
     static func buildTemplate(from schemaData: ContentCardSchemaData,
-                              customizer: ContentCardCustomizer?) -> (any ContentCardTemplate)? {
+                              customizer: ContentCardCustomizable?) -> (any ContentCardTemplate)? {
         switch schemaData.templateType {
         case .smallImage:
             return SmallImageTemplate(schemaData, customizer)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
@@ -41,7 +41,7 @@ public class AEPButton: ObservableObject, AEPViewModel {
         // Extract the button text
         // Bail out if the button text is not present
         guard let buttonTextData = schemaData[Constants.CardTemplate.UIElement.Button.TEXT] as? [String: Any],
-              let buttonText = AEPText(buttonTextData) else {
+              let buttonText = AEPText(buttonTextData, type: .button) else {
             return nil
         }
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButton.swift
@@ -27,7 +27,7 @@ public class AEPButton: ObservableObject, AEPViewModel {
     @Published public var modifier: AEPViewModifier?
 
     /// The parent template that contains this button.
-    let parentTemplate: any ContentCardTemplate
+    weak var parentTemplate: (any ContentCardTemplate)?
 
     public lazy var view: some View = AEPButtonView(model: self)
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButtonView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButtonView.swift
@@ -13,7 +13,7 @@
 import SwiftUI
 
 /// A view that displays an button based on the provided `AEPButton` model.
-public struct AEPButtonView: View {
+struct AEPButtonView: View {
     /// The model containing the data about the button.
     @ObservedObject public var model: AEPButton
 
@@ -23,9 +23,9 @@ public struct AEPButtonView: View {
     }
 
     /// The body of the view
-    public var body: some View {
+    var body: some View {
         Button(action: {
-            model.parentTemplate.eventHandler?.onInteract(interactionId: model.interactId, actionURL: model.actionUrl)
+            model.parentTemplate?.eventHandler?.onInteract(interactionId: model.interactId, actionURL: model.actionUrl)
         }, label: {
             model.text.view
         })

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButtonView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPButton/AEPButtonView.swift
@@ -15,10 +15,10 @@ import SwiftUI
 /// A view that displays an button based on the provided `AEPButton` model.
 struct AEPButtonView: View {
     /// The model containing the data about the button.
-    @ObservedObject public var model: AEPButton
+    @ObservedObject var model: AEPButton
 
     /// Initializes a new instance of `AEPButtonView` with the provided model
-    public init(model: AEPButton) {
+    init(model: AEPButton) {
         self.model = model
     }
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButton.swift
@@ -13,7 +13,7 @@ import AEPServices
 import SwiftUI
 
 public class AEPDismissButton: ObservableObject, AEPViewModel {
-    /// custom view modifier that can be applied to the button view.
+    /// custom view modifier that can be applied to the dismiss button view.
     @Published public var modifier: AEPViewModifier?
 
     /// The image for the dismiss button
@@ -38,7 +38,7 @@ public class AEPDismissButton: ObservableObject, AEPViewModel {
     }
 
     private static func createDismissImage(_ data: [String: Any]) -> AEPImage? {
-        guard let styleString = data["style"] as? String,
+        guard let styleString = data[Constants.CardTemplate.DismissButton.STYLE] as? String,
               let style = DismissButtonStyle(rawValue: styleString.lowercased()) else {
             Log.warning(label: Constants.LOG_TAG, "Dismiss button not created, invalid or missing style property.")
             return nil

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButton.swift
@@ -20,7 +20,7 @@ public class AEPDismissButton: ObservableObject, AEPViewModel {
     @Published public var image: AEPImage
 
     /// Alignment for the dismiss button rendered as an overlay on the card's template
-    @Published public var alignment: Alignment?
+    @Published public var alignment: Alignment = Constants.CardTemplate.DefaultStyle.DismissButton.ALIGNMENT
 
     /// The parent template that contains this button.
     weak var parentTemplate: (any ContentCardTemplate)?

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButton.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButton.swift
@@ -1,0 +1,54 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import AEPServices
+import SwiftUI
+
+public class AEPDismissButton: ObservableObject, AEPViewModel {
+    /// custom view modifier that can be applied to the button view.
+    @Published public var modifier: AEPViewModifier?
+
+    /// The image for the dismiss button
+    @Published public var image: AEPImage
+
+    /// Alignment for the dismiss button rendered as an overlay on the card's template
+    @Published public var alignment: Alignment?
+
+    /// The parent template that contains this button.
+    weak var parentTemplate: (any ContentCardTemplate)?
+
+    public lazy var view: some View = AEPDismissButtonView(model: self)
+
+    init?(_ data: [String: Any], _ template: any ContentCardTemplate) {
+        // bail out, if we cannot create a dismiss button Image
+        guard let dismissImage = AEPDismissButton.createDismissImage(data) else {
+            return nil
+        }
+
+        self.parentTemplate = template
+        self.image = dismissImage
+    }
+
+    private static func createDismissImage(_ data: [String: Any]) -> AEPImage? {
+        guard let styleString = data["style"] as? String,
+              let style = DismissButtonStyle(rawValue: styleString.lowercased()) else {
+            Log.warning(label: Constants.LOG_TAG, "Dismiss button not created, invalid or missing style property.")
+            return nil
+        }
+
+        guard let iconName = style.iconName else {
+            Log.trace(label: Constants.LOG_TAG, "Dismiss button style set to 'none'. No button will be created.")
+            return nil
+        }
+
+        return AEPImage([Constants.CardTemplate.UIElement.Image.ICON: iconName])
+    }
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButtonView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButtonView.swift
@@ -1,0 +1,33 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import SwiftUI
+
+/// A view that displays an button based on the provided `AEPDismissButton` model.
+struct AEPDismissButtonView: View {
+    /// The model containing the data about the button.
+    @ObservedObject public var model: AEPDismissButton
+
+    /// Initializes a new instance of `AEPButtonView` with the provided model
+    public init(model: AEPDismissButton) {
+        self.model = model
+    }
+
+    /// The body of the view
+    public var body: some View {
+        Button(action: {
+            model.parentTemplate?.eventHandler?.onDismiss()
+        }, label: {
+            model.image.view
+        })
+        .applyModifier(model.modifier)
+    }
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButtonView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/AEPDismissButtonView.swift
@@ -17,12 +17,12 @@ struct AEPDismissButtonView: View {
     @ObservedObject public var model: AEPDismissButton
 
     /// Initializes a new instance of `AEPButtonView` with the provided model
-    public init(model: AEPDismissButton) {
+    init(model: AEPDismissButton) {
         self.model = model
     }
 
     /// The body of the view
-    public var body: some View {
+    var body: some View {
         Button(action: {
             model.parentTemplate?.eventHandler?.onDismiss()
         }, label: {

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/DismissButtonStyle.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPDismissButton/DismissButtonStyle.swift
@@ -1,0 +1,29 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+enum DismissButtonStyle: String {
+    case simple
+    case circle
+    case none
+
+    var iconName: String? {
+        switch self {
+        case .simple:
+            return Constants.CardTemplate.DismissButton.Icon.SIMPLE
+        case .circle:
+            return Constants.CardTemplate.DismissButton.Icon.CIRCLE
+        case .none:
+            return nil
+        }
+    }
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
@@ -35,7 +35,7 @@ public class AEPImage: ObservableObject, AEPViewModel {
     @Published public var iconFont: Font?
 
     /// The color of the SF Symbol icon used in the image
-    @Published public var iconColor: Color?
+    @Published public var iconColor = Color.primary
 
     /// custom view modifier that can be applied to the image view.
     @Published public var modifier: AEPViewModifier?

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImage.swift
@@ -27,6 +27,16 @@ public class AEPImage: ObservableObject, AEPViewModel {
     /// The name of the dark mode image bundled resource.
     var darkBundle: String?
 
+    /// The name of the SF Symbol icon used in the image
+    @Published public var icon: String?
+
+    /// The font of the SF Symbol icon used in the image
+    /// Set the size and weight of SF Symbol using the font property
+    @Published public var iconFont: Font?
+
+    /// The color of the SF Symbol icon used in the image
+    @Published public var iconColor: Color?
+
     /// custom view modifier that can be applied to the image view.
     @Published public var modifier: AEPViewModifier?
 
@@ -56,6 +66,13 @@ public class AEPImage: ObservableObject, AEPViewModel {
             self.imageSourceType = .bundle
             self.bundle = bundle
             self.darkBundle = data[Constants.CardTemplate.UIElement.Image.DARK_BUNDLE] as? String
+            return
+        }
+
+        // Attempt to initialize from icon
+        if let icon = data[Constants.CardTemplate.UIElement.Image.ICON] as? String {
+            self.imageSourceType = .icon
+            self.icon = icon
             return
         }
 

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImageView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImageView.swift
@@ -25,26 +25,38 @@ struct AEPImageView: View {
 
     /// Initializes a new instance of `AEPImageView` with the provided model
     /// - Parameter model: The `AEPImage` model containing information about the image to display.
-    public init(model: AEPImage) {
+    init(model: AEPImage) {
         self.model = model
     }
 
     /// The body of the view
-    public var body: some View {
+    var body: some View {
         Group {
             switch model.imageSourceType {
             case .url:
-                AsyncImage(url: themeBasedURL()) { image in
-                    image.resizable()
-                        .aspectRatio(contentMode: model.contentMode)
-                } placeholder: {
-                    ProgressView()
+                AsyncImage(url: themeBasedURL()) { phase in
+                    if let image = phase.image {
+                        // the actual image on successful download
+                        image.resizable()
+                            .aspectRatio(contentMode: model.contentMode)
+                    } else if phase.error != nil {
+                        // when error do not show imageView
+                        EmptyView()
+                    } else {
+                        // Placeholder view
+                        ProgressView()
+                    }
                 }
 
             case .bundle:
                 Image(themeBasedBundledImage())
                     .resizable()
                     .aspectRatio(contentMode: model.contentMode)
+
+            case .icon:
+                safeIconImage(icon: model.icon)
+                    .foregroundColor(model.iconColor)
+                    .font(model.iconFont)
             }
         }.applyModifier(model.modifier)
     }
@@ -66,6 +78,21 @@ struct AEPImageView: View {
             return model.darkBundle ?? model.bundle!
         } else {
             return model.bundle!
+        }
+    }
+
+    /// Returns a system icon image or an empty view.
+    /// This method creates an `Image` view from the provided system icon name if it is valid.
+    /// If the icon name is nil or does not correspond to a valid system icon, it returns an `EmptyView`.
+    ///
+    /// - Parameter icon: An optional `String` representing the system icon name.
+    /// - Returns: An `Image` view if the icon name is valid; otherwise, an `EmptyView`.
+    @ViewBuilder
+    private func safeIconImage(icon: String?) -> some View {
+        if let icon = icon, UIImage(systemName: icon) != nil {
+            Image(systemName: icon)
+        } else {
+            EmptyView()
         }
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImageView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/AEPImageView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// Additionally, the view adapts to light and dark modes, displaying the appropriate image based on the current interface style.
 struct AEPImageView: View {
     /// The model containing the data about the image.
-    @ObservedObject public var model: AEPImage
+    @ObservedObject var model: AEPImage
 
     /// The environment’s color scheme (light or dark mode).
     @Environment(\.colorScheme) var colorScheme

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/ImageSourceType.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPImage/ImageSourceType.swift
@@ -19,4 +19,7 @@ enum ImageSourceType {
 
     /// Indicates that the image is sourced from a bundled resource within the app
     case bundle
+
+    /// Indicates that the image is sourced from SF Symbols
+    case icon
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/AEPStack.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/AEPStack.swift
@@ -20,7 +20,7 @@ public class AEPStack: ObservableObject {
     @Published var childModels: [any AEPViewModel] = []
 
     /// The spacing between child views in the stack.
-    @Published public var spacing: CGFloat?
+    @Published public var spacing: CGFloat = Constants.CardTemplate.DefaultStyle.Stack.SPACING
 
     /// custom view modifier that can be applied to the stack view.
     @Published public var modifier: AEPViewModifier?

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStack.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStack.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// A model class representing a horizontal stack used for Content Cards
 public class AEPHStack: AEPStack, AEPViewModel {
     /// The vertical alignment of child views in the horizontal stack.
-    @Published public var alignment: VerticalAlignment?
+    @Published public var alignment: VerticalAlignment = Constants.CardTemplate.DefaultStyle.Stack.VERTICAL_ALIGNMENT
 
     /// The SwiftUI view representing the horizontal stack.
     public lazy var view: some View = AEPHStackView(model: self)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStackView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStackView.swift
@@ -18,7 +18,7 @@ struct AEPHStackView: View {
 
     /// The body of the view
     var body: some View {
-        HStack(alignment: model.alignment ?? .center, spacing: model.spacing ?? 0) {
+        HStack(alignment: model.alignment, spacing: model.spacing) {
             ForEach(Array(model.childModels.enumerated()), id: \.offset) { _, model in
                 AnyView(model.view)
             }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStackView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/HStack/AEPHStackView.swift
@@ -12,12 +12,12 @@
 
 import SwiftUI
 
-public struct AEPHStackView: View {
+struct AEPHStackView: View {
     /// The model containing the data about the button.
     @ObservedObject var model = AEPHStack()
 
     /// The body of the view
-    public var body: some View {
+    var body: some View {
         HStack(alignment: model.alignment ?? .center, spacing: model.spacing ?? 0) {
             ForEach(Array(model.childModels.enumerated()), id: \.offset) { _, model in
                 AnyView(model.view)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStack.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStack.swift
@@ -16,7 +16,7 @@ import SwiftUI
 /// A model class representing a vertical stack used for Content Cards
 public class AEPVStack: AEPStack, AEPViewModel {
     /// The horizontal alignment of child views in the vertical stack.
-    @Published public var alignment: HorizontalAlignment?
+    @Published public var alignment: HorizontalAlignment = Constants.CardTemplate.DefaultStyle.Stack.HORIZONTAL_ALIGNMENT
 
     /// The SwiftUI view representing the vertical stack.
     public lazy var view: some View = AEPVStackView(model: self)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStackView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStackView.swift
@@ -18,7 +18,7 @@ struct AEPVStackView: View {
 
     /// The body of the view
     var body: some View {
-        VStack(alignment: model.alignment ?? .center, spacing: model.spacing ?? 0) {
+        VStack(alignment: model.alignment, spacing: model.spacing) {
             ForEach(Array(model.childModels.enumerated()), id: \.offset) { _, model in
                 AnyView(model.view)
             }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStackView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPStack/VStack/AEPVStackView.swift
@@ -12,12 +12,12 @@
 
 import SwiftUI
 
-public struct AEPVStackView: View {
+struct AEPVStackView: View {
     /// The model containing the vertical stacks data
     @ObservedObject var model = AEPVStack()
 
     /// The body of the view
-    public var body: some View {
+    var body: some View {
         VStack(alignment: model.alignment ?? .center, spacing: model.spacing ?? 0) {
             ForEach(Array(model.childModels.enumerated()), id: \.offset) { _, model in
                 AnyView(model.view)

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPText.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPText.swift
@@ -32,14 +32,17 @@ public class AEPText: ObservableObject, AEPViewModel {
 
     /// Initializes a new instance of `AEPText`
     /// Failable initializer, returns nil if the required fields are not present in the data
-    /// - Parameter data: The dictionary containing server side styling and content of the text
-    public init?(_ data: [String: Any]) {
+    /// - Parameters:
+    ///    - data: The dictionary containing server side styling and content of the text
+    ///    - type: The type of text (title or description), determining default styling. Defaults to .body
+    public init?(_ data: [String: Any], type: AEPTextType = .body) {
         guard let content = data[Constants.CardTemplate.UIElement.Text.CONTENT] as? String, !content.isEmpty else {
             return nil
         }
         self.content = content
 
-        // TODO: - Extract font and textColor from data
-        // Not required for Phase 1 (Since we only allow client side customization)
+        // Initialize with default styles
+        self.font = type.defaultFont
+        self.textColor = type.defaultColor
     }
 }

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPTextType.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPTextType.swift
@@ -1,0 +1,44 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import SwiftUI
+
+/// Defines the type of text and its default styling properties
+public enum AEPTextType {
+    case title
+    case body
+    case button
+
+    /// The default font for the text type
+    var defaultFont: Font? {
+        switch self {
+        case .title:
+            return Constants.CardTemplate.DefaultStyle.Text.TITLE_FONT
+        case .body:
+            return Constants.CardTemplate.DefaultStyle.Text.BODY_FONT
+        case .button:
+            return Constants.CardTemplate.DefaultStyle.Text.BUTTON_FONT
+        }
+    }
+
+    /// The default color for the text type
+    var defaultColor: Color? {
+        switch self {
+        case .title:
+            return Constants.CardTemplate.DefaultStyle.Text.TITLE_COLOR
+        case .body:
+            return Constants.CardTemplate.DefaultStyle.Text.BODY_COLOR
+        case .button:
+            return Constants.CardTemplate.DefaultStyle.Text.BUTTON_COLOR
+        }
+    }
+}

--- a/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPTextView.swift
+++ b/Frameworks/AEPSwiftUI/Sources/ContentCards/UIElement/AEPText/AEPTextView.swift
@@ -13,17 +13,17 @@
 import SwiftUI
 
 /// A view that displays an button based on the provided `AEPText` model.
-public struct AEPTextView: View {
+struct AEPTextView: View {
     /// The model containing the data about the text.
-    @ObservedObject public var model: AEPText
+    @ObservedObject var model: AEPText
 
     /// Initializes a new instance of `AEPTextView` with the provided model
-    public init(model: AEPText) {
+    init(model: AEPText) {
         self.model = model
     }
 
     /// The body of the view
-    public var body: some View {
+    var body: some View {
         Text(model.content)
             .font(model.font)
             .foregroundColor(model.textColor)

--- a/Frameworks/AEPSwiftUI/Tests/AEPDismissButtonTests.swift
+++ b/Frameworks/AEPSwiftUI/Tests/AEPDismissButtonTests.swift
@@ -1,0 +1,86 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+
+import XCTest
+@testable import AEPSwiftUI
+@testable import AEPMessaging
+
+class AEPDismissButtonTests: XCTestCase {
+
+    let mockTemplate : MockTemplate = MockTemplate(ContentCardSchemaData.getEmpty())!
+
+    func test_initSimpleStyleDismissButton() {
+        // setup
+        let data = ["style": "simple"]
+        
+        // test
+        let dismissButton = AEPDismissButton(data, mockTemplate)
+        
+        // verify
+        XCTAssertNotNil(dismissButton)
+        XCTAssertEqual(dismissButton?.alignment, Constants.CardTemplate.DefaultStyle.DismissButton.ALIGNMENT)
+        XCTAssertNotNil(dismissButton?.image)
+        XCTAssertEqual(dismissButton?.image.icon, DismissButtonStyle.simple.iconName)
+        XCTAssertNotNil(dismissButton?.parentTemplate)
+    }
+    
+    func test_initCircleStyleDismissButton() {
+        // setup
+        let data = ["style": "circle"]
+        
+        // test
+        let dismissButton = AEPDismissButton(data, mockTemplate)
+        
+        // verify
+        XCTAssertNotNil(dismissButton)
+        XCTAssertEqual(dismissButton?.alignment, Constants.CardTemplate.DefaultStyle.DismissButton.ALIGNMENT)
+        XCTAssertNotNil(dismissButton?.image)
+        XCTAssertEqual(dismissButton?.image.icon, DismissButtonStyle.circle.iconName)
+        XCTAssertNotNil(dismissButton?.parentTemplate)
+    }
+    
+    func test_initNoneStyleDismissButton() {
+        // setup
+        let data = ["style": "none"]
+        
+        // test
+        let dismissButton = AEPDismissButton(data, mockTemplate)
+        
+        // verify
+        XCTAssertNil(dismissButton)
+    }
+    
+    func test_initWithInvalidStyle() {
+        // setup
+        let data = ["style": "invalid_style"]
+        
+        // test
+        let dismissButton = AEPDismissButton(data, mockTemplate)
+        
+        // verify
+        XCTAssertNil(dismissButton)
+    }
+    
+    func test_initWithMissingStyle() {
+        // setup
+        let data: [String: Any] = [:]
+        
+        // test
+        let dismissButton = AEPDismissButton(data, mockTemplate)
+        
+        // verify
+        XCTAssertNil(dismissButton)
+    }
+    
+}

--- a/Frameworks/AEPSwiftUI/Tests/AEPTextTests.swift
+++ b/Frameworks/AEPSwiftUI/Tests/AEPTextTests.swift
@@ -15,7 +15,7 @@ import XCTest
 
 final class AEPTextTests: XCTestCase {
     
-    func testInit_ValidData() {
+    func testInit_validData() {
         // setup
         let data = [Constants.CardTemplate.UIElement.Text.CONTENT: "Text Content"]
         
@@ -25,12 +25,12 @@ final class AEPTextTests: XCTestCase {
         // verify
         XCTAssertNotNil(textElement)
         XCTAssertEqual(textElement?.content, "Text Content")
-        XCTAssertNil(textElement?.font)
-        XCTAssertNil(textElement?.textColor)
+        XCTAssertNotNil(textElement?.font)
+        XCTAssertNotNil(textElement?.textColor)
     }
     
     
-    func testInit_EmptyData() {
+    func testInit_emptyData() {
         // setup
         let data: [String: Any] = [:]
         

--- a/Frameworks/AEPSwiftUI/Tests/AEPTextTypeTests.swift
+++ b/Frameworks/AEPSwiftUI/Tests/AEPTextTypeTests.swift
@@ -1,0 +1,47 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import XCTest
+import SwiftUI
+@testable import AEPSwiftUI
+
+final class AEPTextTypeTests: XCTestCase {
+    
+    // font tests
+    
+    func test_titleDefaultFont() {
+        XCTAssertEqual(AEPTextType.title.defaultFont, Constants.CardTemplate.DefaultStyle.Text.TITLE_FONT)
+    }
+
+    func test_bodyDefaultFont() {
+        XCTAssertEqual(AEPTextType.body.defaultFont, Constants.CardTemplate.DefaultStyle.Text.BODY_FONT)
+    }
+
+    func test_buttonDefaultFont() {
+        XCTAssertEqual(AEPTextType.button.defaultFont, Constants.CardTemplate.DefaultStyle.Text.BUTTON_FONT)
+    }
+    
+    // font tests
+
+    func test_titleDefaultColor() {
+        XCTAssertEqual(AEPTextType.title.defaultColor, Constants.CardTemplate.DefaultStyle.Text.TITLE_COLOR)
+    }
+
+    func test_bodyDefaultColor() {
+        XCTAssertEqual(AEPTextType.body.defaultColor, Constants.CardTemplate.DefaultStyle.Text.BODY_COLOR)
+    }
+
+    func test_buttonDefaultColor() {
+        XCTAssertEqual(AEPTextType.button.defaultColor, Constants.CardTemplate.DefaultStyle.Text.BUTTON_COLOR)
+    }
+
+}

--- a/Frameworks/AEPSwiftUI/Tests/DismissButtonStyleTests.swift
+++ b/Frameworks/AEPSwiftUI/Tests/DismissButtonStyleTests.swift
@@ -1,0 +1,37 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import Foundation
+import XCTest
+@testable import AEPSwiftUI
+@testable import AEPMessaging
+
+class DismissButtonStyleTests: XCTestCase {
+
+    // Test for the 'simple' case
+    func test_iconNameForSimple() {
+        let style = DismissButtonStyle.simple
+        XCTAssertEqual(style.iconName, Constants.CardTemplate.DismissButton.Icon.SIMPLE)
+    }
+
+    // Test for the 'circle' case
+    func test_iconNameForCircle() {
+        let style = DismissButtonStyle.circle
+        XCTAssertEqual(style.iconName, Constants.CardTemplate.DismissButton.Icon.CIRCLE)
+    }
+
+    // Test for the 'none' case
+    func test_iconNameForNone() {
+        let style = DismissButtonStyle.none
+        XCTAssertNil(style.iconName)
+    }
+}

--- a/Frameworks/AEPSwiftUI/Tests/SmallImageTemplateTests.swift
+++ b/Frameworks/AEPSwiftUI/Tests/SmallImageTemplateTests.swift
@@ -17,12 +17,14 @@ import XCTest
 
 final class SmallImageTemplateTests: XCTestCase {
     
+    var emptyCustomizer = EmptyCustomizer()
+    
     func testSmallImageTemplate_happy() {
         // setup
         let schema = ContentCardTestUtil.createContentCardSchemaData(fromFile: "SmallImageTemplate")
 
         // test
-        let smallImageTemplate = SmallImageTemplate(schema)
+        let smallImageTemplate = SmallImageTemplate(schema, emptyCustomizer)
 
         // verify
         XCTAssertNotNil(smallImageTemplate)
@@ -53,7 +55,7 @@ final class SmallImageTemplateTests: XCTestCase {
         let schema = ContentCardSchemaData.getEmpty()
 
         // test and verify
-        XCTAssertNil(SmallImageTemplate(schema))
+        XCTAssertNil(SmallImageTemplate(schema, emptyCustomizer))
     }
     
     
@@ -62,7 +64,7 @@ final class SmallImageTemplateTests: XCTestCase {
         let schema = ContentCardTestUtil.createContentCardSchemaData(fromFile: "SmallImageTemplate_noTitle")
         
         // test and verify
-        XCTAssertNil(SmallImageTemplate(schema))
+        XCTAssertNil(SmallImageTemplate(schema, emptyCustomizer))
     }
 
     func testSmallImageTemplate_schemaWithOnlyTitle() {
@@ -70,7 +72,7 @@ final class SmallImageTemplateTests: XCTestCase {
         let schema = ContentCardTestUtil.createContentCardSchemaData(fromFile: "SmallImageTemplate_onlyTitle")
         
         // test
-        let smallImageTemplate = SmallImageTemplate(schema)
+        let smallImageTemplate = SmallImageTemplate(schema, emptyCustomizer)
 
         // test and verify
         XCTAssertNotNil(smallImageTemplate)
@@ -90,7 +92,7 @@ final class SmallImageTemplateTests: XCTestCase {
         let schema = ContentCardTestUtil.createContentCardSchemaData(fromFile: "SmallImageTemplate_validTitle_invalidOther")
         
         // test
-        let smallImageTemplate = SmallImageTemplate(schema)
+        let smallImageTemplate = SmallImageTemplate(schema, emptyCustomizer)
         
         // test and verify
         XCTAssertNotNil(smallImageTemplate)

--- a/Frameworks/AEPSwiftUI/Tests/Utils/EmptyCustomizer.swift
+++ b/Frameworks/AEPSwiftUI/Tests/Utils/EmptyCustomizer.swift
@@ -13,7 +13,7 @@
 import SwiftUI
 @testable import AEPSwiftUI
 
-class EmptyCustomizer : ContentCardCustomizable {    
+class EmptyCustomizer : ContentCardCustomizing {    
     func customize(template: SmallImageTemplate) {
         // Do nothing
     }

--- a/Frameworks/AEPSwiftUI/Tests/Utils/EmptyCustomizer.swift
+++ b/Frameworks/AEPSwiftUI/Tests/Utils/EmptyCustomizer.swift
@@ -1,0 +1,20 @@
+/*
+ Copyright 2024 Adobe. All rights reserved.
+ This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License. You may obtain a copy
+ of the License at http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software distributed under
+ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ OF ANY KIND, either express or implied. See the License for the specific language
+ governing permissions and limitations under the License.
+ */
+
+import SwiftUI
+@testable import AEPSwiftUI
+
+class EmptyCustomizer : ContentCardCustomizable {    
+    func customize(template: SmallImageTemplate) {
+        // Do nothing
+    }
+}

--- a/TestApps/AEPSwiftUITestApp/HomePage.swift
+++ b/TestApps/AEPSwiftUITestApp/HomePage.swift
@@ -52,7 +52,7 @@ struct HomePage: View {
     }
 }
 
-class HomePageCardCustomizer : ContentCardCustomizer {
+class HomePageCardCustomizer : ContentCardCustomizable {
     
     func customize(template: SmallImageTemplate) {
         

--- a/TestApps/AEPSwiftUITestApp/HomePage.swift
+++ b/TestApps/AEPSwiftUITestApp/HomePage.swift
@@ -14,7 +14,7 @@ import SwiftUI
 import AEPSwiftUI
 import AEPMessaging
 
-struct HomePage: View {
+struct HomePage: View, ContentCardUIEventListening {
     
     @State var savedCards : [ContentCardUI] = []
     
@@ -34,10 +34,11 @@ struct HomePage: View {
             }
         }
         .padding()
-        .onAppear(perform: {
-            
+        .onAppear() {
             let homePageSurface = Surface(path: "homepage")
-            AEPSwiftUI.getContentCardsUI(for: homePageSurface, customizer: HomePageCardCustomizer(),{ result in
+            AEPSwiftUI.getContentCardsUI(for: homePageSurface,
+                                         customizer: HomePageCardCustomizer(),
+                                         listener: self) { result in
                 switch result {
                 case .success(let cards):
                     savedCards = cards
@@ -46,16 +47,28 @@ struct HomePage: View {
                     print(error)
                     
                 }
-            })
-        
-        })
+            }
+        }
+    }
+    
+    func onDisplay(_ card: ContentCardUI) {
+        print("TestAppLog : ContentCard Displayed")
+    }
+    
+    func onDismiss(_ card: ContentCardUI) {
+        print("TestAppLog : ContentCard Dismissed")
+        savedCards.removeAll(where: { $0.id == card.id })
+    }
+    
+    func onInteract(_ card: ContentCardUI, _ interactionId: String, actionURL: URL?) -> Bool {
+        print("TestAppLog : ContentCard Interacted : Interaction - \(interactionId)")
+        return false
     }
 }
 
 class HomePageCardCustomizer : ContentCardCustomizing {
     
     func customize(template: SmallImageTemplate) {
-        
         // customize UI elements
         template.title.textColor = .primary
         template.title.font = .subheadline
@@ -72,6 +85,7 @@ class HomePageCardCustomizer : ContentCardCustomizing {
         template.buttonHStack.modifier = AEPViewModifier(ButtonHStackModifier())
         template.rootHStack.modifier = AEPViewModifier(RootHStackModifier())
         
+        // customize the dismiss buttons
         template.dismissButton?.image.iconColor = .primary
         template.dismissButton?.image.iconFont = .system(size: 10)
     }

--- a/TestApps/AEPSwiftUITestApp/HomePage.swift
+++ b/TestApps/AEPSwiftUITestApp/HomePage.swift
@@ -21,11 +21,11 @@ struct HomePage: View {
     var body: some View {
         Spacer()
         Text("Content Cards").font(.title)
-        ScrollView (.horizontal, showsIndicators: false){
-            LazyHStack(spacing: 20) {
+        ScrollView (.vertical, showsIndicators: false){
+            LazyVStack(spacing: 20) {
                  ForEach(savedCards) { card in
                      card.view
-                         .frame(width: 325, height: 120)
+                         .frame(width: 325, height: 110)
                          .overlay(
                              RoundedRectangle(cornerRadius: 5)
                                 .stroke(Color(.systemGray3), lineWidth: 1)
@@ -58,8 +58,9 @@ class HomePageCardCustomizer : ContentCardCustomizable {
         
         // customize UI elements
         template.title.textColor = .primary
+        template.title.font = .subheadline
         template.body?.textColor = .secondary
-        template.body?.font = .subheadline
+        template.body?.font = .caption
         template.buttons?.first?.text.font = .system(size: 13)
         
         // customize stack structure
@@ -70,6 +71,9 @@ class HomePageCardCustomizer : ContentCardCustomizable {
         // add custom modifiers
         template.buttonHStack.modifier = AEPViewModifier(ButtonHStackModifier())
         template.rootHStack.modifier = AEPViewModifier(RootHStackModifier())
+        
+        template.dismissButton?.image.iconColor = .primary
+        template.dismissButton?.image.iconFont = .system(size: 10)
     }
     
     struct RootHStackModifier : ViewModifier {

--- a/TestApps/AEPSwiftUITestApp/HomePage.swift
+++ b/TestApps/AEPSwiftUITestApp/HomePage.swift
@@ -52,7 +52,7 @@ struct HomePage: View {
     }
 }
 
-class HomePageCardCustomizer : ContentCardCustomizable {
+class HomePageCardCustomizer : ContentCardCustomizing {
     
     func customize(template: SmallImageTemplate) {
         


### PR DESCRIPTION
**Major Changes**
- icon support for AEPImage
- Dismiss button built with SFSymbol icons
- Unit test for Dismiss button 

**Small Changes**
- Renamed `ContentCardCustomizer` protocol to `ContentCardCustomizable` 
- Remove public access for AEPButtonView, AEPHStackView, AEPVStackView, AEPImageView
- AEPButton make parentTemplate reference weak