### PR TITLE
MOB-21536: Don't show left and right arrow buttons for auto carousel notifications

### DIFF
--- a/Frameworks/AEPNotificationContent/AEPNotificationContent.podspec
+++ b/Frameworks/AEPNotificationContent/AEPNotificationContent.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AEPNotificationContent"
-  s.version      = "5.0.0"
+  s.version      = "5.0.1"
   s.summary      = "AEPNotificationContent extension for Adobe Experience Cloud SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The AEPNotificationContent extension is used in conjunction with AEPMessaging or AEPCampaignClassic to deliver push notification with predefined templates.

--- a/Frameworks/AEPNotificationContent/AEPNotificationContent.xcodeproj/project.pbxproj
+++ b/Frameworks/AEPNotificationContent/AEPNotificationContent.xcodeproj/project.pbxproj
@@ -1271,7 +1271,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.0.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPNotificationContent;
@@ -1307,7 +1307,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.0;
+				MARKETING_VERSION = 5.0.1;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPNotificationContent;

--- a/Frameworks/AEPNotificationContent/Sources/Constants.swift
+++ b/Frameworks/AEPNotificationContent/Sources/Constants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum Constants {
     static let LOG_TAG = "AEPNotificationContent"
     static let EXTENSION_NAME = "com.adobe.notificationcontent"
-    static let EXTENSION_VERSION = "5.0.0"
+    static let EXTENSION_VERSION = "5.0.1"
 
     enum PayloadKey {
         static let TEMPLATE_TYPE = "adb_template_type"

--- a/Frameworks/AEPNotificationContent/Sources/Controllers/CarouselTemplateController.swift
+++ b/Frameworks/AEPNotificationContent/Sources/Controllers/CarouselTemplateController.swift
@@ -156,10 +156,13 @@ class CarouselTemplateController: TemplateController, UIScrollViewDelegate {
 
     func setupView() {
         setupScrollView()
-        // setup page control and arrow buttons only if there are more than one carousel items and the carousel mode is manual
-        if payload.carouselItems.count > 1 && payload.carouselMode == CarouselMode.manual {
+        // setup page control only if there are more than one carousel items
+        if payload.carouselItems.count > 1 {
             setupPageControl()
-            setupArrowButtons()
+            // setup the arrow buttons only if the carousel mode is manual
+            if payload.carouselMode == CarouselMode.manual {
+                setupArrowButtons()
+            }
         }
         setupTitleAndDescription()
         view.backgroundColor = payload.backgroundColor

--- a/Frameworks/AEPNotificationContent/Sources/Controllers/CarouselTemplateController.swift
+++ b/Frameworks/AEPNotificationContent/Sources/Controllers/CarouselTemplateController.swift
@@ -156,8 +156,8 @@ class CarouselTemplateController: TemplateController, UIScrollViewDelegate {
 
     func setupView() {
         setupScrollView()
-        // setup page control and arrow buttons only if there are more than one carousel items
-        if payload.carouselItems.count > 1 {
+        // setup page control and arrow buttons only if there are more than one carousel items and the carousel mode is manual
+        if payload.carouselItems.count > 1 && payload.carouselMode == CarouselMode.manual {
             setupPageControl()
             setupArrowButtons()
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Auto carousel notifications were being displayed with left and right arrows to manually change the displayed carousel item. This fix will only show the left and right scroll arrows if the carousel is running in manual mode.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
