### PR TITLE
v5.0.2 - Dev -  Expose click handling to classes subclassing AEPNotificationViewController

### DIFF
--- a/AEPNotificationContent.podspec
+++ b/AEPNotificationContent.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AEPNotificationContent"
-  s.version      = "5.0.1"
+  s.version      = "5.0.2"
   s.summary      = "AEPNotificationContent extension for Adobe Experience Cloud SDK. Written and maintained by Adobe."
   s.description  = <<-DESC
                    The AEPNotificationContent extension is used in conjunction with AEPMessaging or AEPCampaignClassic to deliver push notification with predefined templates.

--- a/AEPNotificationContent.xcodeproj/project.pbxproj
+++ b/AEPNotificationContent.xcodeproj/project.pbxproj
@@ -1256,7 +1256,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.1;
+				MARKETING_VERSION = 5.0.2;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPNotificationContent;
@@ -1292,7 +1292,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 5.0.1;
+				MARKETING_VERSION = 5.0.2;
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.AEPNotificationContent;

--- a/AEPNotificationContent/Sources/AEPNotificationViewController.swift
+++ b/AEPNotificationContent/Sources/AEPNotificationViewController.swift
@@ -15,7 +15,7 @@ import UserNotifications
 import UserNotificationsUI
 
 open class AEPNotificationViewController: UIViewController, UNNotificationContentExtension, TemplateControllerDelegate {
-    var notification: UNNotification?
+    open var notification: UNNotification?
 
     // MARK: - UNNotificationContentExtension delegate methods
 
@@ -113,7 +113,7 @@ open class AEPNotificationViewController: UIViewController, UNNotificationConten
     }
 
     /// Use this method to handle the clickURL from interactions with the push template
-    func handleNotificationClickURL(_ urlString: String?) {
+    open func handleNotificationClickURL(_ urlString: String?) {
         /// If the url is nil or invalid, perform the default action
         /// The default action is to open the app
         guard let urlString = urlString, let url = URL(string: urlString) else {

--- a/AEPNotificationContent/Sources/Constants.swift
+++ b/AEPNotificationContent/Sources/Constants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum Constants {
     static let LOG_TAG = "AEPNotificationContent"
     static let EXTENSION_NAME = "com.adobe.notificationcontent"
-    static let EXTENSION_VERSION = "5.0.1"
+    static let EXTENSION_VERSION = "5.0.2"
 
     enum PayloadKey {
         static let TEMPLATE_TYPE = "adb_template_type"

--- a/Documentation/Sources/handle-click-url.md
+++ b/Documentation/Sources/handle-click-url.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide explains how to handle click URLs in notification templates for iOS applications.
+This guide explains how to custom handle click URL on notification templates built by AEPNotificationContent SDK.
 
 ## Creating a Custom NotificationViewController
 
@@ -45,4 +45,4 @@ class NotificationViewController: AEPNotificationViewController {
 }
 ```
 
-Note: The notification removal code shown above is optional. Include it only if you want to automatically dismiss the notification after handling the URL.
+> Note: The notification removal code shown above is optional. Include it only if you want to automatically dismiss the notification after handling the URL.

--- a/Documentation/Sources/handle-click-url.md
+++ b/Documentation/Sources/handle-click-url.md
@@ -1,0 +1,48 @@
+# Handling Click URLs in Notification Templates
+
+## Overview
+
+This guide explains how to handle click URLs in notification templates for iOS applications.
+
+## Creating a Custom NotificationViewController
+
+To implement custom URL handling, create a notification view controller that inherits from `AEPNotificationViewController`:
+
+```swift
+class NotificationViewController: AEPNotificationViewController {
+    // Implementation details will be added below
+}
+```
+
+## Configuring Info.plist
+
+Add the following entries to your Notification Content extension's Info.plist:
+
+| Key | Type | Value |
+| --- | --- | --- |
+| `NSExtension` > `NSExtensionPrincipalClass` | `String` | `${PRODUCT_MODULE_NAME}.NotificationViewController` |
+| `NSExtension` > `NSExtensionAttributes` > `UNNotificationExtensionUserInteractionEnabled` | `Boolean` | `YES` |
+| `NSExtension` > `NSExtensionAttributes` > `UNNotificationExtensionDefaultContentHidden` | `Boolean` | `YES` |
+| `NSExtension` > `NSExtensionAttributes` > `UNNotificationExtensionCategory` | `String` | `AEPNotification` |
+| `NSExtension` > `NSExtensionAttributes` > `UNNotificationExtensionInitialContentSizeRatio` | `Number` | `0.2` |
+
+Note: Replace `NotificationViewController` in the `NSExtensionPrincipalClass` value with your actual view controller class name if different.
+
+## Implementing URL Handling
+
+Override the `handleNotificationClickURL(_:)` method in your custom NotificationViewController to process click URLs:
+
+```swift
+class NotificationViewController: AEPNotificationViewController {
+    override func handleNotificationClickURL(_ urlString: String?) {
+        // Implement your URL handling logic here
+        
+        // Optional: Remove the notification from the notification center
+        if let notificationId = notification?.request.identifier {
+            UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [notificationId])
+        }
+    }
+}
+```
+
+Note: The notification removal code shown above is optional. Include it only if you want to automatically dismiss the notification after handling the URL.

--- a/TestApps/DemoAppNotificationContent/NotificationViewController.swift
+++ b/TestApps/DemoAppNotificationContent/NotificationViewController.swift
@@ -17,4 +17,7 @@ import AEPNotificationContent
 
 class NotificationViewController: AEPNotificationViewController {
 
+    override func handleNotificationClickURL(_ urlString: String?) {
+        // optionally handle the clicks on Notification template.
+    }
 }


### PR DESCRIPTION
To provide control to track push notification interactions on template. We are exposing handleClickURL method to be overridden by classes which subclasses AEPNotificationController.
The notification instance is  also made open to be accessible in `handleClickURL` method